### PR TITLE
feat: add accountability partners and test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,18 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
+        "@vitejs/plugin-react": "^5.1.4",
+        "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^8",
         "eslint-config-next": "14.2.35",
+        "jsdom": "^28.1.0",
         "postcss": "^8",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
@@ -34,6 +38,20 @@
         "typescript": "^5",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -48,18 +66,255 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -70,9 +325,80 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -83,6 +409,209 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -624,6 +1153,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -717,6 +1264,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -995,6 +1553,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1507,6 +2072,33 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -1553,6 +2145,51 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2196,6 +2833,58 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -2328,6 +3017,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2595,6 +3294,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2648,6 +3366,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2683,6 +3424,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/busboy": {
@@ -2894,6 +3669,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -2922,6 +3704,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2933,6 +3736,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -2948,6 +3777,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3020,6 +3863,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3132,12 +3982,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -3364,6 +4234,16 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4085,6 +4965,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4371,6 +5261,54 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -4415,6 +5353,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4741,6 +5689,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4900,6 +5855,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4964,6 +5958,60 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -5152,6 +6200,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5161,6 +6237,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5184,6 +6267,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5385,6 +6478,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5631,6 +6731,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5767,6 +6880,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6168,6 +7282,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6189,6 +7313,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6233,6 +7371,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6448,6 +7596,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -6912,6 +8073,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6996,6 +8170,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -7150,6 +8331,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7161,6 +8362,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7339,6 +8566,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -7378,6 +8615,37 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -7592,6 +8860,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -7854,6 +9170,30 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "lint": "next lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
@@ -22,14 +25,18 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.57.0",
+    "@vitejs/plugin-react": "^5.1.4",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^8",
     "eslint-config-next": "14.2.35",
+    "jsdom": "^28.1.0",
     "postcss": "^8",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { CheckSquare, Layers, Flame, Settings } from "lucide-react";
+import { CheckSquare, Layers, Flame, Users } from "lucide-react";
 
 export default function DashboardLayout({
   children,
@@ -15,7 +15,7 @@ export default function DashboardLayout({
     { name: "Scorecard", href: "/scorecard", icon: CheckSquare },
     { name: "Stacks", href: "/stacks", icon: Layers },
     { name: "Identity", href: "/identity", icon: Flame },
-    { name: "Settings", href: "/settings", icon: Settings },
+    { name: "Partners", href: "/partners", icon: Users },
   ];
 
   return (

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,6 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function DashboardHome() {
-  // PRD specifies the Scorecard is the primary view constraint for Day 1
-  redirect("/scorecard");
-}

--- a/src/app/(dashboard)/partners/[partnerId]/page.tsx
+++ b/src/app/(dashboard)/partners/[partnerId]/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Loader2, Zap, AlertCircle } from "lucide-react";
+import { usePartners } from "@/hooks/usePartners";
+import { SharedView } from "@/components/partners/SharedView";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { NUDGE_MESSAGES } from "@/types/partners";
+import type { PartnerSnapshot } from "@/types/partners";
+
+export default function PartnerProgressPage() {
+  const params = useParams<{ partnerId: string }>();
+  const router = useRouter();
+  const partnerId = params.partnerId;
+
+  const { fetchPartnerSnapshot, sendNudge, partnerships } = usePartners();
+
+  // --------------- State ---------------
+  const [snapshot, setSnapshot] = useState<PartnerSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [nudgeLoading, setNudgeLoading] = useState(false);
+  const [nudgeSent, setNudgeSent] = useState(false);
+  const [showNudgePicker, setShowNudgePicker] = useState(false);
+
+  // --------------- Fetch snapshot ---------------
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await fetchPartnerSnapshot(partnerId);
+        setSnapshot(data);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to load partner data";
+        setError(message);
+        console.error("PartnerProgress error:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [partnerId, fetchPartnerSnapshot]);
+
+  // --------------- Find the partnership for nudge ---------------
+  const partnership = partnerships.find(
+    (p) =>
+      p.partner_profile.id === partnerId ||
+      p.requester_id === partnerId ||
+      p.partner_id === partnerId
+  );
+
+  // --------------- Nudge handler ---------------
+  const handleNudge = useCallback(
+    async (message: string) => {
+      if (!partnership) return;
+
+      try {
+        setNudgeLoading(true);
+        await sendNudge(partnership.id, partnerId, message);
+        setNudgeSent(true);
+        setShowNudgePicker(false);
+        setTimeout(() => setNudgeSent(false), 2500);
+      } catch (err) {
+        console.error("Failed to send nudge:", err);
+      } finally {
+        setNudgeLoading(false);
+      }
+    },
+    [partnership, partnerId, sendNudge]
+  );
+
+  // --------------- Display name ---------------
+  const displayName =
+    snapshot?.profile.display_name ?? "Partner";
+
+  // --------------- Loading state ---------------
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <div className="flex flex-col items-center gap-3 text-gray-400">
+          <Loader2 className="h-8 w-8 animate-spin" />
+          <span className="text-sm font-medium">
+            Loading progress...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // --------------- Error state ---------------
+  if (error || !snapshot) {
+    return (
+      <div className="mx-auto w-full max-w-lg px-4 py-6">
+        <button
+          type="button"
+          onClick={() => router.push("/partners")}
+          className="mb-6 inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Partners
+        </button>
+
+        <Card className="flex flex-col items-center py-12 text-center">
+          <AlertCircle className="mb-3 h-8 w-8 text-gray-400" />
+          <p className="text-sm font-medium text-negative">
+            {error ?? "Could not load partner data"}
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            Make sure you have an active partnership with this person.
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  // --------------- Render ---------------
+  return (
+    <div className="mx-auto w-full max-w-lg px-4 py-6">
+      {/* Back button */}
+      <button
+        type="button"
+        onClick={() => router.push("/partners")}
+        className="mb-4 inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Partners
+      </button>
+
+      {/* Header */}
+      <div className="mb-6 flex items-center gap-3">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-50 text-xl font-bold text-primary">
+          {displayName.charAt(0).toUpperCase()}
+        </div>
+        <div>
+          <h1 className="font-display text-2xl font-bold tracking-tight text-gray-900">
+            {displayName}&apos;s Progress
+          </h1>
+          <p className="text-sm text-gray-500">Read-only view</p>
+        </div>
+      </div>
+
+      {/* Partner's data */}
+      <SharedView snapshot={snapshot} />
+
+      {/* Nudge section at bottom */}
+      {partnership && (
+        <div className="mt-6">
+          <Card className="space-y-3">
+            <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+              Send Encouragement
+            </h2>
+
+            {!showNudgePicker ? (
+              <Button
+                type="button"
+                variant="primary"
+                fullWidth
+                onClick={() => {
+                  if (nudgeSent) return;
+                  setShowNudgePicker(true);
+                }}
+                disabled={nudgeLoading}
+                className="gap-2"
+              >
+                {nudgeSent ? (
+                  "Nudge sent! ✓"
+                ) : (
+                  <>
+                    <Zap className="h-4 w-4" />
+                    Send a Nudge
+                  </>
+                )}
+              </Button>
+            ) : (
+              <div className="space-y-1.5">
+                {NUDGE_MESSAGES.map((msg) => (
+                  <button
+                    key={msg}
+                    type="button"
+                    onClick={() => handleNudge(msg)}
+                    disabled={nudgeLoading}
+                    className="flex w-full items-center rounded-lg border border-border px-4 py-3 text-left text-sm text-gray-700 transition-colors hover:border-primary hover:bg-indigo-50 hover:text-primary"
+                  >
+                    {msg}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => setShowNudgePicker(false)}
+                  className="mt-2 text-sm font-medium text-gray-400 transition-colors hover:text-gray-600"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/partners/[partnerId]/page.tsx
+++ b/src/app/(dashboard)/partners/[partnerId]/page.tsx
@@ -75,8 +75,7 @@ export default function PartnerProgressPage() {
   );
 
   // --------------- Display name ---------------
-  const displayName =
-    snapshot?.profile.display_name ?? "Partner";
+  const displayName = snapshot?.profile.display_name ?? "Partner";
 
   // --------------- Loading state ---------------
   if (loading) {
@@ -84,9 +83,7 @@ export default function PartnerProgressPage() {
       <div className="flex flex-1 items-center justify-center p-6">
         <div className="flex flex-col items-center gap-3 text-gray-400">
           <Loader2 className="h-8 w-8 animate-spin" />
-          <span className="text-sm font-medium">
-            Loading progress...
-          </span>
+          <span className="text-sm font-medium">Loading progress...</span>
         </div>
       </div>
     );

--- a/src/app/(dashboard)/partners/page.tsx
+++ b/src/app/(dashboard)/partners/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Users,
+  Loader2,
+  Check,
+  X,
+  Link2,
+  Clock,
+} from "lucide-react";
+import { usePartners } from "@/hooks/usePartners";
+import { createClient } from "@/lib/supabase/client";
+import { InvitePartner } from "@/components/partners/InvitePartner";
+import { PartnerCard } from "@/components/partners/PartnerCard";
+import { NudgeBadge } from "@/components/partners/NudgeBadge";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+
+export default function PartnersPage() {
+  const router = useRouter();
+
+  // --------------- Current User ---------------
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user) setCurrentUserId(user.id);
+    };
+    fetchUser();
+  }, []);
+
+  // --------------- Data ---------------
+  const {
+    partnerships,
+    pendingInvites,
+    sentInvites,
+    unreadNudgeCount,
+    nudges,
+    loading,
+    error,
+    generateInviteLink,
+    acceptInvite,
+    declineInvite,
+    removePartner,
+    sendNudge,
+    markNudgesRead,
+  } = usePartners();
+
+  // --------------- Handlers ---------------
+  const handleViewProgress = useCallback(
+    (partnerUserId: string) => {
+      router.push(`/partners/${partnerUserId}`);
+    },
+    [router]
+  );
+
+  const handleRemove = useCallback(
+    async (partnershipId: string) => {
+      const confirmed = window.confirm(
+        "Remove this accountability partner? They will no longer be able to see your progress."
+      );
+      if (!confirmed) return;
+
+      try {
+        await removePartner(partnershipId);
+      } catch {
+        // Error logged inside hook
+      }
+    },
+    [removePartner]
+  );
+
+  const handleAccept = useCallback(
+    async (partnershipId: string) => {
+      try {
+        await acceptInvite(partnershipId);
+      } catch {
+        // Error logged inside hook
+      }
+    },
+    [acceptInvite]
+  );
+
+  const handleDecline = useCallback(
+    async (partnershipId: string) => {
+      try {
+        await declineInvite(partnershipId);
+      } catch {
+        // Error logged inside hook
+      }
+    },
+    [declineInvite]
+  );
+
+  const handleCancelSentInvite = useCallback(
+    async (partnershipId: string) => {
+      try {
+        await removePartner(partnershipId);
+      } catch {
+        // Error logged inside hook
+      }
+    },
+    [removePartner]
+  );
+
+  // --------------- Loading state ---------------
+  if (loading && partnerships.length === 0 && pendingInvites.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <div className="flex flex-col items-center gap-3 text-gray-400">
+          <Loader2 className="h-8 w-8 animate-spin" />
+          <span className="text-sm font-medium">Loading partners...</span>
+        </div>
+      </div>
+    );
+  }
+
+  // --------------- Error state ---------------
+  if (
+    error &&
+    partnerships.length === 0 &&
+    pendingInvites.length === 0
+  ) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+          <p className="text-sm font-medium text-negative">{error}</p>
+          <p className="text-sm text-gray-500">
+            Check your connection and try refreshing.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // --------------- Check if there's any content at all ---------------
+  const hasContent =
+    partnerships.length > 0 ||
+    pendingInvites.length > 0 ||
+    sentInvites.length > 0;
+
+  // --------------- Render ---------------
+  return (
+    <div className="mx-auto w-full max-w-lg px-4 py-6">
+      {/* Page heading + nudge bell */}
+      <div className="mb-2 flex items-start justify-between">
+        <div>
+          <h1 className="font-display text-2xl font-bold tracking-tight text-gray-900">
+            Partners
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Stay accountable together. Share your progress and motivate each
+            other.
+          </p>
+        </div>
+        <NudgeBadge
+          nudges={nudges}
+          unreadCount={unreadNudgeCount}
+          onMarkRead={markNudgesRead}
+        />
+      </div>
+
+      <div className="mt-8 space-y-8">
+        {/* ─── Invite Section ─────────────────────── */}
+        <Card>
+          <InvitePartner onGenerateLink={generateInviteLink} />
+        </Card>
+
+        {/* ─── Pending Invites (sent to you) ──────── */}
+        {pendingInvites.length > 0 && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+              Pending Invites
+            </h2>
+            {pendingInvites.map((invite) => (
+              <Card key={invite.id} className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-lg font-bold text-primary">
+                    {(
+                      invite.partner_profile.display_name ?? "?"
+                    )
+                      .charAt(0)
+                      .toUpperCase()}
+                  </div>
+                  <div>
+                    <p className="text-sm font-bold text-gray-900">
+                      {invite.partner_profile.display_name ?? "Someone"}{" "}
+                      <span className="font-normal text-gray-500">
+                        wants to partner with you
+                      </span>
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      {new Date(invite.created_at).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleAccept(invite.id)}
+                    aria-label="Accept invite"
+                    className="flex h-10 w-10 items-center justify-center rounded-full bg-green-50 text-positive transition-colors hover:bg-green-100"
+                  >
+                    <Check className="h-5 w-5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDecline(invite.id)}
+                    aria-label="Decline invite"
+                    className="flex h-10 w-10 items-center justify-center rounded-full bg-red-50 text-negative transition-colors hover:bg-red-100"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {/* ─── Active Partners ────────────────────── */}
+        {partnerships.length > 0 && currentUserId && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+              Your Partners
+            </h2>
+            {partnerships.map((partnership) => (
+              <PartnerCard
+                key={partnership.id}
+                partnership={partnership}
+                currentUserId={currentUserId}
+                onViewProgress={handleViewProgress}
+                onSendNudge={sendNudge}
+                onRemove={handleRemove}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* ─── Sent Invites (waiting for acceptance) ─ */}
+        {sentInvites.length > 0 && (
+          <div className="space-y-3">
+            <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+              Sent Invites
+            </h2>
+            {sentInvites.map((invite) => (
+              <Card
+                key={invite.id}
+                className="flex items-center justify-between gap-4"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+                    <Clock className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-gray-700">
+                      Invite pending
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      Sent{" "}
+                      {new Date(invite.created_at).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleCancelSentInvite(invite.id)}
+                  className="text-sm font-medium text-gray-400 transition-colors hover:text-negative"
+                >
+                  Cancel
+                </button>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {/* ─── Empty State ───────────────────────── */}
+        {!hasContent && (
+          <div className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-200 px-6 py-16 text-center">
+            <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-indigo-50">
+              <Users className="h-7 w-7 text-primary" />
+            </div>
+            <h3 className="mb-2 font-display text-lg font-bold text-gray-900">
+              Better together
+            </h3>
+            <p className="mb-2 max-w-xs text-sm text-gray-500">
+              Invite a friend, family member, or colleague. They&apos;ll see
+              your habit streaks and can send you a nudge when you need it.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/partners/page.tsx
+++ b/src/app/(dashboard)/partners/page.tsx
@@ -2,14 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import {
-  Users,
-  Loader2,
-  Check,
-  X,
-  Link2,
-  Clock,
-} from "lucide-react";
+import { Users, Loader2, Check, X, Link2, Clock } from "lucide-react";
 import { usePartners } from "@/hooks/usePartners";
 import { createClient } from "@/lib/supabase/client";
 import { InvitePartner } from "@/components/partners/InvitePartner";
@@ -122,11 +115,7 @@ export default function PartnersPage() {
   }
 
   // --------------- Error state ---------------
-  if (
-    error &&
-    partnerships.length === 0 &&
-    pendingInvites.length === 0
-  ) {
+  if (error && partnerships.length === 0 && pendingInvites.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <div className="flex max-w-sm flex-col items-center gap-3 text-center">
@@ -179,12 +168,13 @@ export default function PartnersPage() {
               Pending Invites
             </h2>
             {pendingInvites.map((invite) => (
-              <Card key={invite.id} className="flex items-center justify-between gap-4">
+              <Card
+                key={invite.id}
+                className="flex items-center justify-between gap-4"
+              >
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-lg font-bold text-primary">
-                    {(
-                      invite.partner_profile.display_name ?? "?"
-                    )
+                    {(invite.partner_profile.display_name ?? "?")
                       .charAt(0)
                       .toUpperCase()}
                   </div>

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Flame, Loader2, UserCheck, AlertCircle, XCircle } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import type { Partnership } from "@/types/partners";
+
+type InviteState =
+  | "loading"
+  | "ready"
+  | "accepting"
+  | "accepted"
+  | "error_self"
+  | "error_already_partners"
+  | "error_used"
+  | "error_not_found"
+  | "error_generic"
+  | "declined";
+
+export default function InviteAcceptPage() {
+  const params = useParams<{ token: string }>();
+  const router = useRouter();
+  const token = params.token;
+
+  const [state, setState] = useState<InviteState>("loading");
+  const [partnership, setPartnership] = useState<Partnership | null>(null);
+  const [requesterName, setRequesterName] = useState<string | null>(null);
+
+  // ─── Load invite data ──────────────────────────────
+
+  useEffect(() => {
+    const loadInvite = async () => {
+      try {
+        const supabase = createClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          // Shouldn't happen (middleware protects this), but just in case
+          router.push("/login");
+          return;
+        }
+
+        // Fetch the partnership by token
+        const { data: invite, error: inviteError } = await supabase
+          .from("partnerships")
+          .select("*")
+          .eq("invite_token", token)
+          .single();
+
+        if (inviteError || !invite) {
+          setState("error_not_found");
+          return;
+        }
+
+        const typedInvite = invite as Partnership;
+
+        // Check: is this your own invite?
+        if (typedInvite.requester_id === user.id) {
+          setState("error_self");
+          return;
+        }
+
+        // Check: invite already accepted by someone else?
+        if (
+          typedInvite.status === "active" &&
+          typedInvite.partner_id &&
+          typedInvite.partner_id !== user.id
+        ) {
+          setState("error_used");
+          return;
+        }
+
+        // Check: already accepted by you (revisiting the link)
+        if (
+          typedInvite.status === "active" &&
+          typedInvite.partner_id === user.id
+        ) {
+          setState("accepted");
+          setPartnership(typedInvite);
+          return;
+        }
+
+        // Check: already have an active partnership with this person
+        const { data: existing } = await supabase
+          .from("partnerships")
+          .select("id")
+          .eq("status", "active")
+          .or(
+            `and(requester_id.eq.${user.id},partner_id.eq.${typedInvite.requester_id}),and(requester_id.eq.${typedInvite.requester_id},partner_id.eq.${user.id})`
+          )
+          .limit(1);
+
+        if (existing && existing.length > 0) {
+          setState("error_already_partners");
+          return;
+        }
+
+        // Check: invite was declined
+        if (typedInvite.status === "declined") {
+          setState("error_not_found");
+          return;
+        }
+
+        // Fetch requester's display name
+        const { data: profile } = await supabase
+          .from("profiles")
+          .select("display_name")
+          .eq("id", typedInvite.requester_id)
+          .single();
+
+        setRequesterName(profile?.display_name ?? null);
+        setPartnership(typedInvite);
+        setState("ready");
+      } catch {
+        setState("error_generic");
+      }
+    };
+
+    loadInvite();
+  }, [token, router]);
+
+  // ─── Accept ────────────────────────────────────────
+
+  const handleAccept = useCallback(async () => {
+    if (!partnership) return;
+
+    try {
+      setState("accepting");
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error("Not authenticated");
+
+      const { error: updateError } = await supabase
+        .from("partnerships")
+        .update({ partner_id: user.id, status: "active" })
+        .eq("id", partnership.id);
+
+      if (updateError) throw updateError;
+
+      setState("accepted");
+    } catch {
+      setState("error_generic");
+    }
+  }, [partnership]);
+
+  // ─── Decline ───────────────────────────────────────
+
+  const handleDecline = useCallback(async () => {
+    if (!partnership) return;
+
+    try {
+      const supabase = createClient();
+
+      const { error: updateError } = await supabase
+        .from("partnerships")
+        .update({ status: "declined" })
+        .eq("id", partnership.id);
+
+      if (updateError) throw updateError;
+
+      setState("declined");
+    } catch {
+      setState("error_generic");
+    }
+  }, [partnership]);
+
+  // ─── Render ────────────────────────────────────────
+
+  const displayName = requesterName ?? "Someone";
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-surface px-4 py-12">
+      {/* Logo */}
+      <div className="mb-8 flex items-center gap-2">
+        <Flame className="h-6 w-6 text-primary" />
+        <span className="font-display text-2xl font-bold tracking-tight text-gray-900">
+          Forge
+        </span>
+      </div>
+
+      <div className="w-full max-w-sm">
+        {/* Loading */}
+        {state === "loading" && (
+          <Card className="flex flex-col items-center py-12 text-center">
+            <Loader2 className="mb-3 h-8 w-8 animate-spin text-gray-400" />
+            <p className="text-sm text-gray-500">Loading invite...</p>
+          </Card>
+        )}
+
+        {/* Ready to accept */}
+        {state === "ready" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 text-2xl font-bold text-primary">
+                {displayName.charAt(0).toUpperCase()}
+              </div>
+              <h1 className="font-display text-xl font-bold text-gray-900">
+                Partner Invite
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                <span className="font-semibold text-gray-900">
+                  {displayName}
+                </span>{" "}
+                wants you to be their accountability partner on Forge.
+              </p>
+              <p className="mt-1 text-xs text-gray-400">
+                You&apos;ll be able to see each other&apos;s habit streaks and
+                send encouragement.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3">
+              <Button
+                type="button"
+                variant="primary"
+                fullWidth
+                onClick={handleAccept}
+              >
+                Accept Partnership
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                fullWidth
+                onClick={handleDecline}
+              >
+                Decline
+              </Button>
+            </div>
+          </Card>
+        )}
+
+        {/* Accepting */}
+        {state === "accepting" && (
+          <Card className="flex flex-col items-center py-12 text-center">
+            <Loader2 className="mb-3 h-8 w-8 animate-spin text-primary" />
+            <p className="text-sm text-gray-500">Setting up partnership...</p>
+          </Card>
+        )}
+
+        {/* Accepted */}
+        {state === "accepted" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
+                <UserCheck className="h-8 w-8 text-positive" />
+              </div>
+              <h1 className="font-display text-xl font-bold text-gray-900">
+                You&apos;re partners!
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                You and{" "}
+                <span className="font-semibold text-gray-900">
+                  {displayName}
+                </span>{" "}
+                can now see each other&apos;s progress and send nudges.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              fullWidth
+              onClick={() => router.push("/partners")}
+            >
+              Go to Partners
+            </Button>
+          </Card>
+        )}
+
+        {/* Declined */}
+        {state === "declined" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <p className="text-sm text-gray-500">
+                Invite declined. No worries.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              fullWidth
+              onClick={() => router.push("/scorecard")}
+            >
+              Back to Scorecard
+            </Button>
+          </Card>
+        )}
+
+        {/* Error: self invite */}
+        {state === "error_self" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
+                <AlertCircle className="h-8 w-8 text-gray-400" />
+              </div>
+              <h1 className="font-display text-lg font-bold text-gray-900">
+                This is your own invite
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                You can&apos;t partner with yourself. Share this link with
+                someone else!
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              fullWidth
+              onClick={() => router.push("/partners")}
+            >
+              Back to Partners
+            </Button>
+          </Card>
+        )}
+
+        {/* Error: already partners */}
+        {state === "error_already_partners" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50">
+                <UserCheck className="h-8 w-8 text-primary" />
+              </div>
+              <h1 className="font-display text-lg font-bold text-gray-900">
+                Already partners
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                You already have an active partnership with this person.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              fullWidth
+              onClick={() => router.push("/partners")}
+            >
+              Go to Partners
+            </Button>
+          </Card>
+        )}
+
+        {/* Error: invite used by someone else */}
+        {state === "error_used" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+                <XCircle className="h-8 w-8 text-negative" />
+              </div>
+              <h1 className="font-display text-lg font-bold text-gray-900">
+                Invite already used
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                This invite has already been accepted by someone else.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              fullWidth
+              onClick={() => router.push("/partners")}
+            >
+              Back to Partners
+            </Button>
+          </Card>
+        )}
+
+        {/* Error: not found / expired */}
+        {state === "error_not_found" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+                <XCircle className="h-8 w-8 text-negative" />
+              </div>
+              <h1 className="font-display text-lg font-bold text-gray-900">
+                Invite not found
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                This invite link is invalid, expired, or has been cancelled.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              fullWidth
+              onClick={() => router.push("/scorecard")}
+            >
+              Back to Scorecard
+            </Button>
+          </Card>
+        )}
+
+        {/* Error: generic */}
+        {state === "error_generic" && (
+          <Card className="space-y-6 text-center">
+            <div className="flex flex-col items-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+                <XCircle className="h-8 w-8 text-negative" />
+              </div>
+              <h1 className="font-display text-lg font-bold text-gray-900">
+                Something went wrong
+              </h1>
+              <p className="mt-2 text-sm text-gray-500">
+                Please try again or ask your partner to send a new invite.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              fullWidth
+              onClick={() => router.push("/scorecard")}
+            >
+              Back to Scorecard
+            </Button>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/identity/__tests__/identity.test.tsx
+++ b/src/components/identity/__tests__/identity.test.tsx
@@ -1,0 +1,352 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { IdentityCard } from "../IdentityCard";
+import { IdentityForm } from "../IdentityForm";
+import { VoteCounter } from "../VoteCounter";
+import type { IdentityWithDetails } from "@/types/identity";
+import type { Routine } from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "u1",
+    name: "Read",
+    tag: "positive",
+    time_of_day: "evening",
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeIdentity(
+  overrides: Partial<IdentityWithDetails> = {}
+): IdentityWithDetails {
+  return {
+    id: "i1",
+    user_id: "u1",
+    statement: "I am someone who reads daily",
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    linked_routines: [makeRoutine({ id: "r1", name: "Read" })],
+    total_votes: 15,
+    votes_this_week: 5,
+    votes_today: 1,
+    vote_history: [
+      { date: "2026-03-05", count: 0 },
+      { date: "2026-03-06", count: 1 },
+      { date: "2026-03-07", count: 1 },
+      { date: "2026-03-08", count: 0 },
+      { date: "2026-03-09", count: 1 },
+      { date: "2026-03-10", count: 1 },
+      { date: "2026-03-11", count: 1 },
+    ],
+    ...overrides,
+  };
+}
+
+// ─── IdentityCard ────────────────────────────────────────
+
+describe("IdentityCard", () => {
+  const defaultProps = {
+    identity: makeIdentity(),
+    onEdit: vi.fn(),
+    onManageLinks: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  it("renders identity statement in quotes", () => {
+    render(<IdentityCard {...defaultProps} />);
+    expect(
+      screen.getByText(/I am someone who reads daily/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows weekly progress percentage", () => {
+    // 1 linked routine × 7 days = 7 max, 5 votes this week = 71%
+    render(<IdentityCard {...defaultProps} />);
+    expect(screen.getByText(/5\/7 votes/)).toBeInTheDocument();
+  });
+
+  it("renders linked routine chips", () => {
+    render(<IdentityCard {...defaultProps} />);
+    expect(screen.getByText("Read")).toBeInTheDocument();
+  });
+
+  it("shows 'Link habits' button when no routines linked", () => {
+    const identity = makeIdentity({ linked_routines: [] });
+    render(<IdentityCard {...defaultProps} identity={identity} />);
+    expect(screen.getByText(/Link habits to start voting/)).toBeInTheDocument();
+  });
+
+  it("opens menu on kebab click", () => {
+    render(<IdentityCard {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Identity options"));
+    expect(screen.getByText("Edit statement")).toBeInTheDocument();
+    expect(screen.getByText("Manage linked habits")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
+  it("calls onEdit when edit is clicked", () => {
+    const onEdit = vi.fn();
+    render(<IdentityCard {...defaultProps} onEdit={onEdit} />);
+    fireEvent.click(screen.getByLabelText("Identity options"));
+    fireEvent.click(screen.getByText("Edit statement"));
+    expect(onEdit).toHaveBeenCalledWith(defaultProps.identity);
+  });
+
+  it("calls onDelete when delete is clicked", () => {
+    const onDelete = vi.fn();
+    render(<IdentityCard {...defaultProps} onDelete={onDelete} />);
+    fireEvent.click(screen.getByLabelText("Identity options"));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith("i1");
+  });
+
+  it("calls onManageLinks when clicked", () => {
+    const onManageLinks = vi.fn();
+    render(
+      <IdentityCard {...defaultProps} onManageLinks={onManageLinks} />
+    );
+    fireEvent.click(screen.getByLabelText("Identity options"));
+    fireEvent.click(screen.getByText("Manage linked habits"));
+    expect(onManageLinks).toHaveBeenCalledWith(defaultProps.identity);
+  });
+});
+
+// ─── IdentityForm ────────────────────────────────────────
+
+describe("IdentityForm", () => {
+  const routines = [
+    makeRoutine({ id: "r1", name: "Read" }),
+    makeRoutine({ id: "r2", name: "Exercise", tag: "positive" }),
+  ];
+
+  it("renders create mode with empty input and routine picker", () => {
+    render(
+      <IdentityForm
+        mode="create"
+        routines={routines}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByText("Identity statement")).toBeInTheDocument();
+    expect(screen.getByText("Link habits to this identity")).toBeInTheDocument();
+    expect(screen.getByText("Read")).toBeInTheDocument();
+    expect(screen.getByText("Exercise")).toBeInTheDocument();
+    expect(screen.getByText("Create Identity")).toBeInTheDocument();
+  });
+
+  it("renders edit mode with pre-filled statement", () => {
+    const identity = makeIdentity({ statement: "I am healthy" });
+    render(
+      <IdentityForm
+        mode="edit"
+        identity={identity}
+        routines={routines}
+        onClose={() => {}}
+      />
+    );
+    const input = screen.getByDisplayValue("I am healthy");
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText("Save Changes")).toBeInTheDocument();
+  });
+
+  it("renders links mode with routine picker only", () => {
+    const identity = makeIdentity();
+    render(
+      <IdentityForm
+        mode="links"
+        identity={identity}
+        routines={routines}
+        onClose={() => {}}
+      />
+    );
+    // Should NOT show statement input
+    expect(screen.queryByText("Identity statement")).not.toBeInTheDocument();
+    // Should show routine picker
+    expect(screen.getByText("Link habits to this identity")).toBeInTheDocument();
+    expect(screen.getByText("Update Links")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <IdentityForm mode="create" routines={routines} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows selected count when routines are toggled", () => {
+    render(
+      <IdentityForm mode="create" routines={routines} onClose={() => {}} />
+    );
+    expect(screen.getByText("0 habits selected")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Read"));
+    expect(screen.getByText("1 habit selected")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no routines exist", () => {
+    render(
+      <IdentityForm mode="create" routines={[]} onClose={() => {}} />
+    );
+    expect(screen.getByText(/No routines yet/)).toBeInTheDocument();
+  });
+
+  it("calls onSubmitCreate with statement and routine ids", async () => {
+    const onSubmitCreate = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <IdentityForm
+        mode="create"
+        routines={routines}
+        onSubmitCreate={onSubmitCreate}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/I am someone/), {
+      target: { value: "I am a morning person" },
+    });
+    fireEvent.click(screen.getByText("Read"));
+    fireEvent.click(screen.getByText("Create Identity"));
+
+    await waitFor(() => {
+      expect(onSubmitCreate).toHaveBeenCalledWith("I am a morning person", ["r1"]);
+    });
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("calls onSubmitEdit with id and statement", async () => {
+    const onSubmitEdit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const identity = makeIdentity({ id: "i1", statement: "I am healthy" });
+    render(
+      <IdentityForm
+        mode="edit"
+        identity={identity}
+        routines={routines}
+        onSubmitEdit={onSubmitEdit}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.change(screen.getByDisplayValue("I am healthy"), {
+      target: { value: "I am very healthy" },
+    });
+    fireEvent.click(screen.getByText("Save Changes"));
+
+    await waitFor(() => {
+      expect(onSubmitEdit).toHaveBeenCalledWith("i1", "I am very healthy");
+    });
+  });
+
+  it("calls onSubmitLinks with identity id and selected routine ids", async () => {
+    const onSubmitLinks = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const identity = makeIdentity({ id: "i1", linked_routines: [] });
+    render(
+      <IdentityForm
+        mode="links"
+        identity={identity}
+        routines={routines}
+        onSubmitLinks={onSubmitLinks}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Exercise"));
+    fireEvent.click(screen.getByText("Update Links"));
+
+    await waitFor(() => {
+      expect(onSubmitLinks).toHaveBeenCalledWith("i1", ["r2"]);
+    });
+  });
+
+  it("shows error when creating with empty statement", async () => {
+    const onSubmitCreate = vi.fn();
+    render(
+      <IdentityForm
+        mode="create"
+        routines={routines}
+        onSubmitCreate={onSubmitCreate}
+        onClose={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Create Identity"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Identity statement is required")).toBeInTheDocument();
+    });
+    expect(onSubmitCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── VoteCounter ─────────────────────────────────────────
+
+describe("VoteCounter", () => {
+  const defaultHistory = [
+    { date: "2026-03-05", count: 0 },
+    { date: "2026-03-06", count: 1 },
+    { date: "2026-03-07", count: 2 },
+    { date: "2026-03-08", count: 0 },
+    { date: "2026-03-09", count: 1 },
+    { date: "2026-03-10", count: 1 },
+    { date: "2026-03-11", count: 3 },
+  ];
+
+  it("renders total vote count", () => {
+    render(
+      <VoteCounter totalVotes={42} votesToday={0} voteHistory={defaultHistory} />
+    );
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("votes")).toBeInTheDocument();
+  });
+
+  it("shows singular 'vote' for count of 1", () => {
+    render(
+      <VoteCounter totalVotes={1} votesToday={0} voteHistory={defaultHistory} />
+    );
+    expect(screen.getByText("vote")).toBeInTheDocument();
+  });
+
+  it("shows +N today badge when votesToday > 0", () => {
+    render(
+      <VoteCounter totalVotes={10} votesToday={3} voteHistory={defaultHistory} />
+    );
+    expect(screen.getByText("+3 today")).toBeInTheDocument();
+  });
+
+  it("hides today badge when votesToday is 0", () => {
+    render(
+      <VoteCounter totalVotes={10} votesToday={0} voteHistory={defaultHistory} />
+    );
+    expect(screen.queryByText(/today/)).not.toBeInTheDocument();
+  });
+
+  it("renders Last 7 days label", () => {
+    render(
+      <VoteCounter totalVotes={5} votesToday={1} voteHistory={defaultHistory} />
+    );
+    expect(screen.getByText("Last 7 days")).toBeInTheDocument();
+  });
+
+  it("renders 7 day labels", () => {
+    render(
+      <VoteCounter totalVotes={5} votesToday={1} voteHistory={defaultHistory} />
+    );
+    // 7 day labels should be rendered (S, M, T, W, T, F, S pattern)
+    const dayLabels = screen.getAllByText(/^[SMTWF]$/);
+    expect(dayLabels).toHaveLength(7);
+  });
+});

--- a/src/components/identity/__tests__/identity.test.tsx
+++ b/src/components/identity/__tests__/identity.test.tsx
@@ -111,9 +111,7 @@ describe("IdentityCard", () => {
 
   it("calls onManageLinks when clicked", () => {
     const onManageLinks = vi.fn();
-    render(
-      <IdentityCard {...defaultProps} onManageLinks={onManageLinks} />
-    );
+    render(<IdentityCard {...defaultProps} onManageLinks={onManageLinks} />);
     fireEvent.click(screen.getByLabelText("Identity options"));
     fireEvent.click(screen.getByText("Manage linked habits"));
     expect(onManageLinks).toHaveBeenCalledWith(defaultProps.identity);
@@ -130,14 +128,12 @@ describe("IdentityForm", () => {
 
   it("renders create mode with empty input and routine picker", () => {
     render(
-      <IdentityForm
-        mode="create"
-        routines={routines}
-        onClose={() => {}}
-      />
+      <IdentityForm mode="create" routines={routines} onClose={() => {}} />
     );
     expect(screen.getByText("Identity statement")).toBeInTheDocument();
-    expect(screen.getByText("Link habits to this identity")).toBeInTheDocument();
+    expect(
+      screen.getByText("Link habits to this identity")
+    ).toBeInTheDocument();
     expect(screen.getByText("Read")).toBeInTheDocument();
     expect(screen.getByText("Exercise")).toBeInTheDocument();
     expect(screen.getByText("Create Identity")).toBeInTheDocument();
@@ -171,7 +167,9 @@ describe("IdentityForm", () => {
     // Should NOT show statement input
     expect(screen.queryByText("Identity statement")).not.toBeInTheDocument();
     // Should show routine picker
-    expect(screen.getByText("Link habits to this identity")).toBeInTheDocument();
+    expect(
+      screen.getByText("Link habits to this identity")
+    ).toBeInTheDocument();
     expect(screen.getByText("Update Links")).toBeInTheDocument();
   });
 
@@ -194,9 +192,7 @@ describe("IdentityForm", () => {
   });
 
   it("shows empty state when no routines exist", () => {
-    render(
-      <IdentityForm mode="create" routines={[]} onClose={() => {}} />
-    );
+    render(<IdentityForm mode="create" routines={[]} onClose={() => {}} />);
     expect(screen.getByText(/No routines yet/)).toBeInTheDocument();
   });
 
@@ -219,7 +215,9 @@ describe("IdentityForm", () => {
     fireEvent.click(screen.getByText("Create Identity"));
 
     await waitFor(() => {
-      expect(onSubmitCreate).toHaveBeenCalledWith("I am a morning person", ["r1"]);
+      expect(onSubmitCreate).toHaveBeenCalledWith("I am a morning person", [
+        "r1",
+      ]);
     });
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
@@ -286,7 +284,9 @@ describe("IdentityForm", () => {
     fireEvent.click(screen.getByText("Create Identity"));
 
     await waitFor(() => {
-      expect(screen.getByText("Identity statement is required")).toBeInTheDocument();
+      expect(
+        screen.getByText("Identity statement is required")
+      ).toBeInTheDocument();
     });
     expect(onSubmitCreate).not.toHaveBeenCalled();
   });
@@ -307,7 +307,11 @@ describe("VoteCounter", () => {
 
   it("renders total vote count", () => {
     render(
-      <VoteCounter totalVotes={42} votesToday={0} voteHistory={defaultHistory} />
+      <VoteCounter
+        totalVotes={42}
+        votesToday={0}
+        voteHistory={defaultHistory}
+      />
     );
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("votes")).toBeInTheDocument();
@@ -322,14 +326,22 @@ describe("VoteCounter", () => {
 
   it("shows +N today badge when votesToday > 0", () => {
     render(
-      <VoteCounter totalVotes={10} votesToday={3} voteHistory={defaultHistory} />
+      <VoteCounter
+        totalVotes={10}
+        votesToday={3}
+        voteHistory={defaultHistory}
+      />
     );
     expect(screen.getByText("+3 today")).toBeInTheDocument();
   });
 
   it("hides today badge when votesToday is 0", () => {
     render(
-      <VoteCounter totalVotes={10} votesToday={0} voteHistory={defaultHistory} />
+      <VoteCounter
+        totalVotes={10}
+        votesToday={0}
+        voteHistory={defaultHistory}
+      />
     );
     expect(screen.queryByText(/today/)).not.toBeInTheDocument();
   });

--- a/src/components/partners/InvitePartner.tsx
+++ b/src/components/partners/InvitePartner.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Link2, Check, Copy, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+interface InvitePartnerProps {
+  onGenerateLink: () => Promise<string>;
+}
+
+export function InvitePartner({ onGenerateLink }: InvitePartnerProps) {
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerate = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const url = await onGenerateLink();
+      setInviteUrl(url);
+
+      // Auto-copy to clipboard
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to generate invite link";
+      setError(message);
+      console.error("InvitePartner error:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [onGenerateLink]);
+
+  const handleCopyAgain = useCallback(async () => {
+    if (!inviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // Fallback: select the text so user can manually copy
+      setError("Couldn't copy automatically. Select the link and copy it.");
+    }
+  }, [inviteUrl]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+          Invite a Partner
+        </h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Share a link with someone you trust. They&apos;ll be able to see your
+          progress and send you encouragement.
+        </p>
+      </div>
+
+      {error && (
+        <p className="text-sm font-medium text-negative">{error}</p>
+      )}
+
+      {!inviteUrl ? (
+        <Button
+          type="button"
+          variant="primary"
+          onClick={handleGenerate}
+          loading={loading}
+          className="gap-2"
+        >
+          <Link2 className="h-4 w-4" />
+          Generate Invite Link
+        </Button>
+      ) : (
+        <div className="space-y-3">
+          {/* Show the generated link */}
+          <div className="flex items-center gap-2 rounded-xl border border-border bg-gray-50 px-4 py-3">
+            <span className="min-w-0 flex-1 truncate text-sm text-gray-700">
+              {inviteUrl}
+            </span>
+            <button
+              type="button"
+              onClick={handleCopyAgain}
+              className="flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:bg-indigo-50"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3.5 w-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3.5 w-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Generate another */}
+          <button
+            type="button"
+            onClick={handleGenerate}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-primary"
+          >
+            {loading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Link2 className="h-3.5 w-3.5" />
+            )}
+            Generate new link
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/partners/InvitePartner.tsx
+++ b/src/components/partners/InvitePartner.tsx
@@ -59,9 +59,7 @@ export function InvitePartner({ onGenerateLink }: InvitePartnerProps) {
         </p>
       </div>
 
-      {error && (
-        <p className="text-sm font-medium text-negative">{error}</p>
-      )}
+      {error && <p className="text-sm font-medium text-negative">{error}</p>}
 
       {!inviteUrl ? (
         <Button

--- a/src/components/partners/NudgeBadge.tsx
+++ b/src/components/partners/NudgeBadge.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Bell } from "lucide-react";
+import type { Nudge } from "@/types/partners";
+
+interface NudgeBadgeProps {
+  nudges: Nudge[];
+  unreadCount: number;
+  onMarkRead: () => Promise<void>;
+}
+
+export function NudgeBadge({
+  nudges,
+  unreadCount,
+  onMarkRead,
+}: NudgeBadgeProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleToggle = useCallback(async () => {
+    const willOpen = !isOpen;
+    setIsOpen(willOpen);
+
+    // Mark all as read when opening the panel
+    if (willOpen && unreadCount > 0) {
+      try {
+        await onMarkRead();
+      } catch (err) {
+        console.error("Failed to mark nudges as read:", err);
+      }
+    }
+  }, [isOpen, unreadCount, onMarkRead]);
+
+  // Only show the most recent 10 nudges
+  const recentNudges = nudges.slice(0, 10);
+
+  return (
+    <div className="relative">
+      {/* Bell trigger */}
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-label={`Nudges${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+        className="relative flex h-10 w-10 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+      >
+        <Bell className="h-5 w-5" />
+        {unreadCount > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-negative px-1 text-[10px] font-bold text-white">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown panel */}
+      {isOpen && (
+        <>
+          {/* Backdrop to close on outside click */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+          />
+
+          <div className="absolute right-0 top-full z-50 mt-2 w-72 overflow-hidden rounded-2xl border border-border bg-white shadow-lg">
+            <div className="border-b border-border px-4 py-3">
+              <h3 className="text-sm font-bold text-gray-900">Nudges</h3>
+            </div>
+
+            {recentNudges.length > 0 ? (
+              <div className="max-h-64 overflow-y-auto">
+                {recentNudges.map((nudge) => (
+                  <div
+                    key={nudge.id}
+                    className={`border-b border-border px-4 py-3 last:border-b-0 ${
+                      !nudge.read ? "bg-indigo-50/50" : ""
+                    }`}
+                  >
+                    <p className="text-sm text-gray-800">{nudge.message}</p>
+                    <p className="mt-1 text-[10px] text-gray-400">
+                      {new Date(nudge.created_at).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="px-4 py-8 text-center">
+                <p className="text-sm text-gray-400">No nudges yet</p>
+                <p className="mt-1 text-xs text-gray-400">
+                  Your partners can send you encouragement here
+                </p>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/partners/PartnerCard.tsx
+++ b/src/components/partners/PartnerCard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Eye, Zap, X, Loader2 } from "lucide-react";
+import { Card } from "@/components/ui/Card";
+import { NUDGE_MESSAGES } from "@/types/partners";
+import type { PartnershipWithProfile } from "@/types/partners";
+
+interface PartnerCardProps {
+  partnership: PartnershipWithProfile;
+  currentUserId: string;
+  onViewProgress: (partnerUserId: string) => void;
+  onSendNudge: (
+    partnershipId: string,
+    receiverId: string,
+    message: string
+  ) => Promise<void>;
+  onRemove: (partnershipId: string) => void;
+}
+
+export function PartnerCard({
+  partnership,
+  currentUserId,
+  onViewProgress,
+  onSendNudge,
+  onRemove,
+}: PartnerCardProps) {
+  const [nudgeLoading, setNudgeLoading] = useState(false);
+  const [nudgeSent, setNudgeSent] = useState(false);
+  const [showNudgePicker, setShowNudgePicker] = useState(false);
+
+  const partnerUserId =
+    partnership.requester_id === currentUserId
+      ? partnership.partner_id!
+      : partnership.requester_id;
+
+  const displayName =
+    partnership.partner_profile.display_name ?? "Anonymous Partner";
+
+  const handleNudge = useCallback(
+    async (message: string) => {
+      try {
+        setNudgeLoading(true);
+        await onSendNudge(partnership.id, partnerUserId, message);
+        setNudgeSent(true);
+        setShowNudgePicker(false);
+        setTimeout(() => setNudgeSent(false), 2500);
+      } catch (err) {
+        console.error("Failed to send nudge:", err);
+      } finally {
+        setNudgeLoading(false);
+      }
+    },
+    [partnership.id, partnerUserId, onSendNudge]
+  );
+
+  return (
+    <Card className="relative space-y-4">
+      {/* Header: avatar + name + remove */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 text-lg font-bold text-primary">
+            {displayName.charAt(0).toUpperCase()}
+          </div>
+          <div>
+            <h3 className="font-display text-base font-bold text-gray-900">
+              {displayName}
+            </h3>
+            <p className="text-xs text-gray-400">
+              Partners since{" "}
+              {new Date(partnership.updated_at).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              })}
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => onRemove(partnership.id)}
+          aria-label="Remove partner"
+          className="flex h-8 w-8 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-red-50 hover:text-negative"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onViewProgress(partnerUserId)}
+          className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50"
+        >
+          <Eye className="h-4 w-4" />
+          View Progress
+        </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            if (nudgeSent) return;
+            setShowNudgePicker(!showNudgePicker);
+          }}
+          disabled={nudgeLoading}
+          className={`inline-flex flex-1 items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors ${
+            nudgeSent
+              ? "bg-green-50 text-positive"
+              : "bg-indigo-50 text-primary hover:bg-indigo-100"
+          }`}
+        >
+          {nudgeLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : nudgeSent ? (
+            "Sent! ✓"
+          ) : (
+            <>
+              <Zap className="h-4 w-4" />
+              Nudge
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Nudge message picker */}
+      {showNudgePicker && (
+        <div className="space-y-1.5 rounded-xl border border-border bg-gray-50 p-3">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
+            Pick a message
+          </p>
+          {NUDGE_MESSAGES.map((msg) => (
+            <button
+              key={msg}
+              type="button"
+              onClick={() => handleNudge(msg)}
+              disabled={nudgeLoading}
+              className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-white hover:text-primary"
+            >
+              {msg}
+            </button>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/partners/SharedView.tsx
+++ b/src/components/partners/SharedView.tsx
@@ -40,7 +40,10 @@ function buildChainViews(
   const routineMap = new Map<string, Routine>();
   routines.forEach((r) => routineMap.set(r.id, r));
 
-  const chainMap = new Map<string, { anchor: Routine; steps: { routine: Routine; position: number }[] }>();
+  const chainMap = new Map<
+    string,
+    { anchor: Routine; steps: { routine: Routine; position: number }[] }
+  >();
 
   stacks.forEach((s) => {
     const anchor = routineMap.get(s.anchor_routine_id);
@@ -209,9 +212,7 @@ export function SharedView({ snapshot }: SharedViewProps) {
                           : "border-gray-200 bg-white"
                       }`}
                     >
-                      {isDone && (
-                        <Check className="h-4 w-4" strokeWidth={3} />
-                      )}
+                      {isDone && <Check className="h-4 w-4" strokeWidth={3} />}
                     </div>
 
                     {/* Name */}

--- a/src/components/partners/SharedView.tsx
+++ b/src/components/partners/SharedView.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useMemo } from "react";
+import { Flame, TrendingUp, ArrowDown, Check } from "lucide-react";
+import { Card } from "@/components/ui/Card";
+import type { PartnerSnapshot } from "@/types/partners";
+import type { Routine, CheckIn, HabitStack } from "@/types/database";
+import type { Tag } from "@/types/common";
+
+interface SharedViewProps {
+  snapshot: PartnerSnapshot;
+}
+
+// ─── Shared Style Maps ───────────────────────────────
+
+const TAG_STYLES: Record<Tag, { bg: string; text: string; label: string }> = {
+  positive: { bg: "bg-green-50", text: "text-positive", label: "+" },
+  negative: { bg: "bg-red-50", text: "text-negative", label: "−" },
+  neutral: { bg: "bg-gray-100", text: "text-neutral", label: "=" },
+};
+
+// ─── Helpers ─────────────────────────────────────────
+
+function getLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+interface StackChainView {
+  anchor: Routine;
+  steps: Routine[];
+}
+
+function buildChainViews(
+  stacks: HabitStack[],
+  routines: Routine[]
+): StackChainView[] {
+  const routineMap = new Map<string, Routine>();
+  routines.forEach((r) => routineMap.set(r.id, r));
+
+  const chainMap = new Map<string, { anchor: Routine; steps: { routine: Routine; position: number }[] }>();
+
+  stacks.forEach((s) => {
+    const anchor = routineMap.get(s.anchor_routine_id);
+    const stacked = routineMap.get(s.stacked_routine_id);
+    if (!anchor || !stacked) return;
+
+    const existing = chainMap.get(s.anchor_routine_id);
+    if (existing) {
+      existing.steps.push({ routine: stacked, position: s.position });
+    } else {
+      chainMap.set(s.anchor_routine_id, {
+        anchor,
+        steps: [{ routine: stacked, position: s.position }],
+      });
+    }
+  });
+
+  const chains: StackChainView[] = [];
+  chainMap.forEach((chain) => {
+    chain.steps.sort((a, b) => a.position - b.position);
+    chains.push({
+      anchor: chain.anchor,
+      steps: chain.steps.map((s) => s.routine),
+    });
+  });
+
+  return chains;
+}
+
+// ─── Component ───────────────────────────────────────
+
+export function SharedView({ snapshot }: SharedViewProps) {
+  const today = getLocalDateString(new Date());
+
+  // Build a set of completed routine IDs for today
+  const completedToday = useMemo(() => {
+    const set = new Set<string>();
+    snapshot.checkIns.forEach((ci) => {
+      if (ci.date === today && ci.completed) {
+        set.add(ci.routine_id);
+      }
+    });
+    return set;
+  }, [snapshot.checkIns, today]);
+
+  // Group routines by time of day
+  const timeGroups = useMemo(() => {
+    const groups: { key: string; label: string; routines: Routine[] }[] = [
+      { key: "morning", label: "Morning", routines: [] },
+      { key: "afternoon", label: "Afternoon", routines: [] },
+      { key: "evening", label: "Evening", routines: [] },
+      { key: "night", label: "Night", routines: [] },
+      { key: "anytime", label: "Anytime", routines: [] },
+    ];
+
+    const groupMap = new Map(groups.map((g) => [g.key, g]));
+
+    snapshot.routines.forEach((r) => {
+      const key = r.time_of_day ?? "anytime";
+      const group = groupMap.get(key) ?? groupMap.get("anytime")!;
+      group.routines.push(r);
+    });
+
+    return groups.filter((g) => g.routines.length > 0);
+  }, [snapshot.routines]);
+
+  // Build stack chains for display
+  const chains = useMemo(
+    () => buildChainViews(snapshot.stacks, snapshot.routines),
+    [snapshot.stacks, snapshot.routines]
+  );
+
+  // Today's completion stats
+  const todayTotal = snapshot.routines.length;
+  const todayDone = completedToday.size;
+  const todayPercent =
+    todayTotal > 0 ? Math.round((todayDone / todayTotal) * 100) : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* ─── Streak Summary ─────────────────────── */}
+      <Card className="space-y-4">
+        <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+          Overview
+        </h2>
+
+        <div className="grid grid-cols-3 gap-4">
+          {/* Current streak */}
+          <div className="text-center">
+            <div className="flex items-center justify-center gap-1">
+              <Flame className="h-5 w-5 text-orange-400" />
+              <span className="font-display text-3xl font-bold text-gray-900">
+                {snapshot.currentStreak}
+              </span>
+            </div>
+            <p className="mt-1 text-[10px] font-medium uppercase tracking-widest text-gray-400">
+              Day streak
+            </p>
+          </div>
+
+          {/* Longest streak */}
+          <div className="text-center">
+            <div className="flex items-center justify-center gap-1">
+              <TrendingUp className="h-5 w-5 text-primary" />
+              <span className="font-display text-3xl font-bold text-gray-900">
+                {snapshot.longestStreak}
+              </span>
+            </div>
+            <p className="mt-1 text-[10px] font-medium uppercase tracking-widest text-gray-400">
+              Best streak
+            </p>
+          </div>
+
+          {/* Weekly completion */}
+          <div className="text-center">
+            <span className="font-display text-3xl font-bold text-gray-900">
+              {snapshot.completionRateThisWeek}%
+            </span>
+            <p className="mt-1 text-[10px] font-medium uppercase tracking-widest text-gray-400">
+              This week
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      {/* ─── Today's Scorecard ──────────────────── */}
+      <Card className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+            Today&apos;s Scorecard
+          </h2>
+          <span className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-bold text-primary">
+            {todayDone}/{todayTotal} ({todayPercent}%)
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-500 ease-out"
+            style={{ width: `${todayPercent}%` }}
+          />
+        </div>
+
+        {/* Routine groups */}
+        {timeGroups.map((group) => (
+          <div key={group.key}>
+            <p className="mb-2 text-xs font-semibold text-gray-500">
+              {group.label}
+            </p>
+            <div className="divide-y divide-gray-100 overflow-hidden rounded-xl border border-border">
+              {group.routines.map((routine) => {
+                const isDone = completedToday.has(routine.id);
+                const tag = TAG_STYLES[routine.tag];
+
+                return (
+                  <div
+                    key={routine.id}
+                    className="flex items-center gap-3 px-4 py-3"
+                  >
+                    {/* Completion indicator (read-only, no click) */}
+                    <div
+                      className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border-2 ${
+                        isDone
+                          ? "border-primary bg-primary text-white"
+                          : "border-gray-200 bg-white"
+                      }`}
+                    >
+                      {isDone && (
+                        <Check className="h-4 w-4" strokeWidth={3} />
+                      )}
+                    </div>
+
+                    {/* Name */}
+                    <span
+                      className={`flex-1 text-sm ${
+                        isDone
+                          ? "text-gray-400 line-through decoration-gray-300"
+                          : "font-medium text-gray-900"
+                      }`}
+                    >
+                      {routine.name}
+                    </span>
+
+                    {/* Tag badge */}
+                    <span
+                      className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${tag.bg} ${tag.text}`}
+                    >
+                      {tag.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+
+        {snapshot.routines.length === 0 && (
+          <p className="py-4 text-center text-sm text-gray-400">
+            No routines added yet.
+          </p>
+        )}
+      </Card>
+
+      {/* ─── Habit Stacks ───────────────────────── */}
+      {chains.length > 0 && (
+        <Card className="space-y-4">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-gray-400">
+            Habit Stacks
+          </h2>
+
+          <div className="space-y-4">
+            {chains.map((chain) => (
+              <div
+                key={chain.anchor.id}
+                className="rounded-xl border border-border p-4"
+              >
+                {/* Anchor */}
+                <ChainNode
+                  routine={chain.anchor}
+                  isDone={completedToday.has(chain.anchor.id)}
+                  role="ANCHOR"
+                />
+
+                {/* Steps */}
+                {chain.steps.map((routine) => (
+                  <div key={routine.id}>
+                    <div className="flex items-center gap-2 py-1 pl-5">
+                      <div className="flex flex-col items-center">
+                        <div className="h-3 w-0.5 bg-primary" />
+                        <ArrowDown className="h-3 w-3 text-primary" />
+                      </div>
+                      <span className="text-xs italic text-primary">
+                        then...
+                      </span>
+                    </div>
+                    <ChainNode
+                      routine={routine}
+                      isDone={completedToday.has(routine.id)}
+                      role="STACKED"
+                    />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ─── Chain Node Sub-component ────────────────────────
+
+function ChainNode({
+  routine,
+  isDone,
+  role,
+}: {
+  routine: Routine;
+  isDone: boolean;
+  role: "ANCHOR" | "STACKED";
+}) {
+  const tag = TAG_STYLES[routine.tag];
+
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+          isDone ? "bg-primary text-white" : `${tag.bg} ${tag.text}`
+        }`}
+      >
+        {isDone ? <Check className="h-4 w-4" strokeWidth={3} /> : tag.label}
+      </div>
+      <div>
+        <span className="text-[9px] font-bold uppercase tracking-widest text-gray-400">
+          {role}
+        </span>
+        <span
+          className={`block text-sm ${
+            isDone
+              ? "text-gray-400 line-through decoration-gray-300"
+              : "font-medium text-gray-900"
+          }`}
+        >
+          {routine.name}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/partners/__tests__/partners.test.tsx
+++ b/src/components/partners/__tests__/partners.test.tsx
@@ -5,7 +5,11 @@ import { InvitePartner } from "../InvitePartner";
 import { PartnerCard } from "../PartnerCard";
 import { NudgeBadge } from "../NudgeBadge";
 import { SharedView } from "../SharedView";
-import type { PartnershipWithProfile, Nudge, PartnerSnapshot } from "@/types/partners";
+import type {
+  PartnershipWithProfile,
+  Nudge,
+  PartnerSnapshot,
+} from "@/types/partners";
 import type { Routine } from "@/types/database";
 
 // ─── Factories ───────────────────────────────────────────
@@ -55,18 +59,45 @@ function makeRoutine(overrides: Partial<Routine> = {}): Routine {
   };
 }
 
-function makeSnapshot(overrides: Partial<PartnerSnapshot> = {}): PartnerSnapshot {
+function makeSnapshot(
+  overrides: Partial<PartnerSnapshot> = {}
+): PartnerSnapshot {
   return {
     profile: { id: "user-2", display_name: "Jordan" },
     routines: [
-      makeRoutine({ id: "r1", name: "Morning coffee", tag: "neutral", time_of_day: "morning" }),
-      makeRoutine({ id: "r2", name: "Read 10 pages", tag: "positive", time_of_day: "evening" }),
+      makeRoutine({
+        id: "r1",
+        name: "Morning coffee",
+        tag: "neutral",
+        time_of_day: "morning",
+      }),
+      makeRoutine({
+        id: "r2",
+        name: "Read 10 pages",
+        tag: "positive",
+        time_of_day: "evening",
+      }),
     ],
     checkIns: [
-      { id: "c1", user_id: "user-2", routine_id: "r1", date: new Date().toISOString().slice(0, 10), completed: true, created_at: "", updated_at: "" },
+      {
+        id: "c1",
+        user_id: "user-2",
+        routine_id: "r1",
+        date: new Date().toISOString().slice(0, 10),
+        completed: true,
+        created_at: "",
+        updated_at: "",
+      },
     ],
     stacks: [
-      { id: "s1", user_id: "user-2", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "" },
+      {
+        id: "s1",
+        user_id: "user-2",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+        created_at: "",
+      },
     ],
     currentStreak: 5,
     longestStreak: 12,
@@ -92,18 +123,24 @@ describe("InvitePartner", () => {
   });
 
   it("shows URL after generating", async () => {
-    const onGenerate = vi.fn().mockResolvedValue("https://forge.app/invite/abc-123");
+    const onGenerate = vi
+      .fn()
+      .mockResolvedValue("https://forge.app/invite/abc-123");
     render(<InvitePartner onGenerateLink={onGenerate} />);
 
     fireEvent.click(screen.getByText("Generate Invite Link"));
 
     await waitFor(() => {
-      expect(screen.getByText("https://forge.app/invite/abc-123")).toBeInTheDocument();
+      expect(
+        screen.getByText("https://forge.app/invite/abc-123")
+      ).toBeInTheDocument();
     });
   });
 
   it("copies to clipboard on generate", async () => {
-    const onGenerate = vi.fn().mockResolvedValue("https://forge.app/invite/abc-123");
+    const onGenerate = vi
+      .fn()
+      .mockResolvedValue("https://forge.app/invite/abc-123");
     render(<InvitePartner onGenerateLink={onGenerate} />);
 
     fireEvent.click(screen.getByText("Generate Invite Link"));
@@ -116,7 +153,9 @@ describe("InvitePartner", () => {
   });
 
   it("shows Copied! feedback after copy", async () => {
-    const onGenerate = vi.fn().mockResolvedValue("https://forge.app/invite/abc-123");
+    const onGenerate = vi
+      .fn()
+      .mockResolvedValue("https://forge.app/invite/abc-123");
     render(<InvitePartner onGenerateLink={onGenerate} />);
 
     fireEvent.click(screen.getByText("Generate Invite Link"));
@@ -219,13 +258,19 @@ describe("PartnerCard", () => {
 
 describe("NudgeBadge", () => {
   it("renders bell icon", () => {
-    render(<NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />);
+    render(
+      <NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />
+    );
     expect(screen.getByLabelText("Nudges")).toBeInTheDocument();
   });
 
   it("shows unread count badge", () => {
     render(
-      <NudgeBadge nudges={[makeNudge()]} unreadCount={3} onMarkRead={async () => {}} />
+      <NudgeBadge
+        nudges={[makeNudge()]}
+        unreadCount={3}
+        onMarkRead={async () => {}}
+      />
     );
     expect(screen.getByText("3")).toBeInTheDocument();
   });
@@ -238,13 +283,17 @@ describe("NudgeBadge", () => {
   });
 
   it("hides badge when unread is 0", () => {
-    render(<NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />);
+    render(
+      <NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />
+    );
     expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 
   it("opens dropdown on click", () => {
     const nudges = [makeNudge({ id: "n1", message: "Stay strong!" })];
-    render(<NudgeBadge nudges={nudges} unreadCount={1} onMarkRead={async () => {}} />);
+    render(
+      <NudgeBadge nudges={nudges} unreadCount={1} onMarkRead={async () => {}} />
+    );
 
     fireEvent.click(screen.getByLabelText(/Nudges/));
     expect(screen.getByText("Stay strong!")).toBeInTheDocument();
@@ -253,7 +302,9 @@ describe("NudgeBadge", () => {
   it("calls onMarkRead when opened with unread nudges", async () => {
     const onMarkRead = vi.fn().mockResolvedValue(undefined);
     const nudges = [makeNudge()];
-    render(<NudgeBadge nudges={nudges} unreadCount={1} onMarkRead={onMarkRead} />);
+    render(
+      <NudgeBadge nudges={nudges} unreadCount={1} onMarkRead={onMarkRead} />
+    );
 
     fireEvent.click(screen.getByLabelText(/Nudges/));
 
@@ -263,14 +314,18 @@ describe("NudgeBadge", () => {
   });
 
   it("shows empty state when no nudges", () => {
-    render(<NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />);
+    render(
+      <NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />
+    );
     fireEvent.click(screen.getByLabelText("Nudges"));
     expect(screen.getByText("No nudges yet")).toBeInTheDocument();
   });
 
   it("shows nudge timestamp", () => {
     const nudges = [makeNudge({ id: "n1", message: "Go!" })];
-    render(<NudgeBadge nudges={nudges} unreadCount={0} onMarkRead={async () => {}} />);
+    render(
+      <NudgeBadge nudges={nudges} unreadCount={0} onMarkRead={async () => {}} />
+    );
     fireEvent.click(screen.getByLabelText("Nudges"));
     // Should render the formatted date
     expect(screen.getByText("Go!")).toBeInTheDocument();
@@ -286,7 +341,10 @@ describe("SharedView", () => {
     expect(screen.getByText("12")).toBeInTheDocument(); // longest streak
     // React splits {number}% into separate text nodes, use a function matcher
     const weeklyEl = screen.getByText((_, el) => {
-      return el?.tagName === "SPAN" && !!el?.textContent?.replace(/\s/g, "").includes("68%");
+      return (
+        el?.tagName === "SPAN" &&
+        !!el?.textContent?.replace(/\s/g, "").includes("68%")
+      );
     });
     expect(weeklyEl).toBeInTheDocument();
   });
@@ -306,8 +364,12 @@ describe("SharedView", () => {
   it("renders routine names", () => {
     render(<SharedView snapshot={makeSnapshot()} />);
     // Routines appear in both scorecard and stacks sections
-    expect(screen.getAllByText("Morning coffee").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("Read 10 pages").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Morning coffee").length).toBeGreaterThanOrEqual(
+      1
+    );
+    expect(screen.getAllByText("Read 10 pages").length).toBeGreaterThanOrEqual(
+      1
+    );
   });
 
   it("renders completion fraction", () => {

--- a/src/components/partners/__tests__/partners.test.tsx
+++ b/src/components/partners/__tests__/partners.test.tsx
@@ -1,0 +1,350 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { InvitePartner } from "../InvitePartner";
+import { PartnerCard } from "../PartnerCard";
+import { NudgeBadge } from "../NudgeBadge";
+import { SharedView } from "../SharedView";
+import type { PartnershipWithProfile, Nudge, PartnerSnapshot } from "@/types/partners";
+import type { Routine } from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makePartnership(
+  overrides: Partial<PartnershipWithProfile> = {}
+): PartnershipWithProfile {
+  return {
+    id: "p1",
+    requester_id: "user-1",
+    partner_id: "user-2",
+    invite_token: "tok-123",
+    invite_email: null,
+    status: "active",
+    created_at: "2026-03-01T00:00:00Z",
+    updated_at: "2026-03-05T00:00:00Z",
+    partner_profile: { id: "user-2", display_name: "Jordan" },
+    ...overrides,
+  };
+}
+
+function makeNudge(overrides: Partial<Nudge> = {}): Nudge {
+  return {
+    id: "n1",
+    partnership_id: "p1",
+    sender_id: "user-2",
+    receiver_id: "user-1",
+    message: "Keep going! 💪",
+    read: false,
+    created_at: "2026-03-11T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "user-2",
+    name: "Morning coffee",
+    tag: "neutral",
+    time_of_day: "morning",
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<PartnerSnapshot> = {}): PartnerSnapshot {
+  return {
+    profile: { id: "user-2", display_name: "Jordan" },
+    routines: [
+      makeRoutine({ id: "r1", name: "Morning coffee", tag: "neutral", time_of_day: "morning" }),
+      makeRoutine({ id: "r2", name: "Read 10 pages", tag: "positive", time_of_day: "evening" }),
+    ],
+    checkIns: [
+      { id: "c1", user_id: "user-2", routine_id: "r1", date: new Date().toISOString().slice(0, 10), completed: true, created_at: "", updated_at: "" },
+    ],
+    stacks: [
+      { id: "s1", user_id: "user-2", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "" },
+    ],
+    currentStreak: 5,
+    longestStreak: 12,
+    completionRateThisWeek: 68,
+    ...overrides,
+  };
+}
+
+// ─── Mock clipboard ──────────────────────────────────────
+
+beforeEach(() => {
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+// ─── InvitePartner ───────────────────────────────────────
+
+describe("InvitePartner", () => {
+  it("renders generate button", () => {
+    render(<InvitePartner onGenerateLink={async () => ""} />);
+    expect(screen.getByText("Generate Invite Link")).toBeInTheDocument();
+  });
+
+  it("shows URL after generating", async () => {
+    const onGenerate = vi.fn().mockResolvedValue("https://forge.app/invite/abc-123");
+    render(<InvitePartner onGenerateLink={onGenerate} />);
+
+    fireEvent.click(screen.getByText("Generate Invite Link"));
+
+    await waitFor(() => {
+      expect(screen.getByText("https://forge.app/invite/abc-123")).toBeInTheDocument();
+    });
+  });
+
+  it("copies to clipboard on generate", async () => {
+    const onGenerate = vi.fn().mockResolvedValue("https://forge.app/invite/abc-123");
+    render(<InvitePartner onGenerateLink={onGenerate} />);
+
+    fireEvent.click(screen.getByText("Generate Invite Link"));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "https://forge.app/invite/abc-123"
+      );
+    });
+  });
+
+  it("shows Copied! feedback after copy", async () => {
+    const onGenerate = vi.fn().mockResolvedValue("https://forge.app/invite/abc-123");
+    render(<InvitePartner onGenerateLink={onGenerate} />);
+
+    fireEvent.click(screen.getByText("Generate Invite Link"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error on failure", async () => {
+    const onGenerate = vi.fn().mockRejectedValue(new Error("Network error"));
+    render(<InvitePartner onGenerateLink={onGenerate} />);
+
+    fireEvent.click(screen.getByText("Generate Invite Link"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── PartnerCard ─────────────────────────────────────────
+
+describe("PartnerCard", () => {
+  const defaultProps = {
+    partnership: makePartnership(),
+    currentUserId: "user-1",
+    onViewProgress: vi.fn(),
+    onSendNudge: vi.fn().mockResolvedValue(undefined),
+    onRemove: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultProps.onViewProgress = vi.fn();
+    defaultProps.onSendNudge = vi.fn().mockResolvedValue(undefined);
+    defaultProps.onRemove = vi.fn();
+  });
+
+  it("renders partner name", () => {
+    render(<PartnerCard {...defaultProps} />);
+    expect(screen.getByText("Jordan")).toBeInTheDocument();
+  });
+
+  it("renders avatar initial", () => {
+    render(<PartnerCard {...defaultProps} />);
+    expect(screen.getByText("J")).toBeInTheDocument();
+  });
+
+  it("shows partners since date", () => {
+    render(<PartnerCard {...defaultProps} />);
+    expect(screen.getByText(/Partners since/)).toBeInTheDocument();
+  });
+
+  it("calls onViewProgress when View Progress is clicked", () => {
+    render(<PartnerCard {...defaultProps} />);
+    fireEvent.click(screen.getByText("View Progress"));
+    expect(defaultProps.onViewProgress).toHaveBeenCalledWith("user-2");
+  });
+
+  it("opens nudge picker when Nudge is clicked", () => {
+    render(<PartnerCard {...defaultProps} />);
+    fireEvent.click(screen.getByText("Nudge"));
+    expect(screen.getByText("Pick a message")).toBeInTheDocument();
+    expect(screen.getByText("Keep going! 💪")).toBeInTheDocument();
+  });
+
+  it("calls onSendNudge when a nudge message is selected", async () => {
+    render(<PartnerCard {...defaultProps} />);
+    fireEvent.click(screen.getByText("Nudge"));
+    fireEvent.click(screen.getByText("Keep going! 💪"));
+
+    await waitFor(() => {
+      expect(defaultProps.onSendNudge).toHaveBeenCalledWith(
+        "p1",
+        "user-2",
+        "Keep going! 💪"
+      );
+    });
+  });
+
+  it("calls onRemove when X is clicked", () => {
+    render(<PartnerCard {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Remove partner"));
+    expect(defaultProps.onRemove).toHaveBeenCalledWith("p1");
+  });
+
+  it("shows Sent! after nudge is sent", async () => {
+    render(<PartnerCard {...defaultProps} />);
+    fireEvent.click(screen.getByText("Nudge"));
+    fireEvent.click(screen.getByText("Keep going! 💪"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sent! ✓")).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── NudgeBadge ──────────────────────────────────────────
+
+describe("NudgeBadge", () => {
+  it("renders bell icon", () => {
+    render(<NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />);
+    expect(screen.getByLabelText("Nudges")).toBeInTheDocument();
+  });
+
+  it("shows unread count badge", () => {
+    render(
+      <NudgeBadge nudges={[makeNudge()]} unreadCount={3} onMarkRead={async () => {}} />
+    );
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows 9+ for counts over 9", () => {
+    render(
+      <NudgeBadge nudges={[]} unreadCount={15} onMarkRead={async () => {}} />
+    );
+    expect(screen.getByText("9+")).toBeInTheDocument();
+  });
+
+  it("hides badge when unread is 0", () => {
+    render(<NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />);
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("opens dropdown on click", () => {
+    const nudges = [makeNudge({ id: "n1", message: "Stay strong!" })];
+    render(<NudgeBadge nudges={nudges} unreadCount={1} onMarkRead={async () => {}} />);
+
+    fireEvent.click(screen.getByLabelText(/Nudges/));
+    expect(screen.getByText("Stay strong!")).toBeInTheDocument();
+  });
+
+  it("calls onMarkRead when opened with unread nudges", async () => {
+    const onMarkRead = vi.fn().mockResolvedValue(undefined);
+    const nudges = [makeNudge()];
+    render(<NudgeBadge nudges={nudges} unreadCount={1} onMarkRead={onMarkRead} />);
+
+    fireEvent.click(screen.getByLabelText(/Nudges/));
+
+    await waitFor(() => {
+      expect(onMarkRead).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("shows empty state when no nudges", () => {
+    render(<NudgeBadge nudges={[]} unreadCount={0} onMarkRead={async () => {}} />);
+    fireEvent.click(screen.getByLabelText("Nudges"));
+    expect(screen.getByText("No nudges yet")).toBeInTheDocument();
+  });
+
+  it("shows nudge timestamp", () => {
+    const nudges = [makeNudge({ id: "n1", message: "Go!" })];
+    render(<NudgeBadge nudges={nudges} unreadCount={0} onMarkRead={async () => {}} />);
+    fireEvent.click(screen.getByLabelText("Nudges"));
+    // Should render the formatted date
+    expect(screen.getByText("Go!")).toBeInTheDocument();
+  });
+});
+
+// ─── SharedView ──────────────────────────────────────────
+
+describe("SharedView", () => {
+  it("renders streak summary", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    expect(screen.getByText("5")).toBeInTheDocument(); // current streak
+    expect(screen.getByText("12")).toBeInTheDocument(); // longest streak
+    // React splits {number}% into separate text nodes, use a function matcher
+    const weeklyEl = screen.getByText((_, el) => {
+      return el?.tagName === "SPAN" && !!el?.textContent?.replace(/\s/g, "").includes("68%");
+    });
+    expect(weeklyEl).toBeInTheDocument();
+  });
+
+  it("renders streak labels", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    expect(screen.getByText("Day streak")).toBeInTheDocument();
+    expect(screen.getByText("Best streak")).toBeInTheDocument();
+    expect(screen.getByText("This week")).toBeInTheDocument();
+  });
+
+  it("renders today's scorecard section", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    expect(screen.getByText("Today's Scorecard")).toBeInTheDocument();
+  });
+
+  it("renders routine names", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    // Routines appear in both scorecard and stacks sections
+    expect(screen.getAllByText("Morning coffee").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Read 10 pages").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders completion fraction", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    // Completion badge contains the total routine count
+    const badge = screen.getByText((_, el) => {
+      return el?.tagName === "SPAN" && !!el?.textContent?.includes("/2");
+    });
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("renders habit stacks section when stacks exist", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    expect(screen.getByText("Habit Stacks")).toBeInTheDocument();
+  });
+
+  it("renders ANCHOR and STACKED labels in stacks", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    expect(screen.getByText("ANCHOR")).toBeInTheDocument();
+    expect(screen.getByText("STACKED")).toBeInTheDocument();
+  });
+
+  it("renders empty message when no routines", () => {
+    const snapshot = makeSnapshot({ routines: [], checkIns: [], stacks: [] });
+    render(<SharedView snapshot={snapshot} />);
+    expect(screen.getByText("No routines added yet.")).toBeInTheDocument();
+  });
+
+  it("hides stacks section when no stacks", () => {
+    const snapshot = makeSnapshot({ stacks: [] });
+    render(<SharedView snapshot={snapshot} />);
+    expect(screen.queryByText("Habit Stacks")).not.toBeInTheDocument();
+  });
+
+  it("groups routines by time of day", () => {
+    render(<SharedView snapshot={makeSnapshot()} />);
+    expect(screen.getByText("Morning")).toBeInTheDocument();
+    expect(screen.getByText("Evening")).toBeInTheDocument();
+  });
+});

--- a/src/components/scorecard/__tests__/scorecard.test.tsx
+++ b/src/components/scorecard/__tests__/scorecard.test.tsx
@@ -77,10 +77,7 @@ describe("ScorecardSummary", () => {
   });
 
   it("counts only completed check-ins", () => {
-    const routines = [
-      makeRoutine({ id: "r1" }),
-      makeRoutine({ id: "r2" }),
-    ];
+    const routines = [makeRoutine({ id: "r1" }), makeRoutine({ id: "r2" })];
     const checkIns = new Map<string, CheckIn>();
     checkIns.set("r1", makeCheckIn({ routine_id: "r1", completed: true }));
     checkIns.set("r2", makeCheckIn({ routine_id: "r2", completed: false }));
@@ -284,25 +281,29 @@ describe("RoutineGroup", () => {
 
 describe("AddRoutineForm", () => {
   it("renders form fields", () => {
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />);
     expect(screen.getByText("Routine name")).toBeInTheDocument();
-    expect(screen.getByText("How does this habit affect you?")).toBeInTheDocument();
-    expect(screen.getByText("When do you usually do this?")).toBeInTheDocument();
+    expect(
+      screen.getByText("How does this habit affect you?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("When do you usually do this?")
+    ).toBeInTheDocument();
   });
 
   it("shows Add Routine button in create mode", () => {
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />);
     expect(screen.getByText("Add Routine")).toBeInTheDocument();
   });
 
   it("shows Save Changes button in edit mode", () => {
     const routine = makeRoutine({ name: "Exercise" });
     render(
-      <AddRoutineForm routine={routine} onSubmit={async () => {}} onClose={() => {}} />
+      <AddRoutineForm
+        routine={routine}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     expect(screen.getByText("Save Changes")).toBeInTheDocument();
   });
@@ -310,24 +311,24 @@ describe("AddRoutineForm", () => {
   it("pre-fills name in edit mode", () => {
     const routine = makeRoutine({ name: "Exercise" });
     render(
-      <AddRoutineForm routine={routine} onSubmit={async () => {}} onClose={() => {}} />
+      <AddRoutineForm
+        routine={routine}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     expect(screen.getByDisplayValue("Exercise")).toBeInTheDocument();
   });
 
   it("renders all tag options", () => {
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />);
     expect(screen.getByText("Positive (+)")).toBeInTheDocument();
     expect(screen.getByText("Negative (−)")).toBeInTheDocument();
     expect(screen.getByText("Neutral (=)")).toBeInTheDocument();
   });
 
   it("renders all time of day options", () => {
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />);
     expect(screen.getByText("Morning")).toBeInTheDocument();
     expect(screen.getByText("Afternoon")).toBeInTheDocument();
     expect(screen.getByText("Evening")).toBeInTheDocument();
@@ -337,17 +338,13 @@ describe("AddRoutineForm", () => {
 
   it("calls onClose when Cancel is clicked", () => {
     const onClose = vi.fn();
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={onClose} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={onClose} />);
     fireEvent.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalledOnce();
   });
 
   it("allows selecting a tag", () => {
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />);
     const positiveBtn = screen.getByText("Positive (+)");
     fireEvent.click(positiveBtn);
     // After click, the button should have the active class
@@ -355,9 +352,7 @@ describe("AddRoutineForm", () => {
   });
 
   it("allows selecting a time of day", () => {
-    render(
-      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
-    );
+    render(<AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />);
     const morningBtn = screen.getByText("Morning");
     fireEvent.click(morningBtn);
     expect(morningBtn.className).toContain("border-primary");

--- a/src/components/scorecard/__tests__/scorecard.test.tsx
+++ b/src/components/scorecard/__tests__/scorecard.test.tsx
@@ -1,0 +1,419 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ScorecardSummary } from "../ScorecardSummary";
+import { DateNavigator } from "../DateNavigator";
+import { RoutineGroup } from "../RoutineGroup";
+import { RoutineItem } from "../RoutineItem";
+import { AddRoutineForm } from "../AddRoutineForm";
+import type { Routine, CheckIn } from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "u1",
+    name: "Morning coffee",
+    tag: "neutral",
+    time_of_day: "morning",
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeCheckIn(overrides: Partial<CheckIn> = {}): CheckIn {
+  return {
+    id: "ci1",
+    user_id: "u1",
+    routine_id: "r1",
+    date: "2026-03-11",
+    completed: true,
+    created_at: "2026-03-11T08:00:00Z",
+    updated_at: "2026-03-11T08:00:00Z",
+    ...overrides,
+  };
+}
+
+// ─── ScorecardSummary ────────────────────────────────────
+
+describe("ScorecardSummary", () => {
+  it("renders completed count and total", () => {
+    const routines = [
+      makeRoutine({ id: "r1", tag: "positive" }),
+      makeRoutine({ id: "r2", tag: "negative" }),
+    ];
+    const checkIns = new Map<string, CheckIn>();
+    checkIns.set("r1", makeCheckIn({ routine_id: "r1", completed: true }));
+
+    render(<ScorecardSummary routines={routines} checkIns={checkIns} />);
+    expect(screen.getByText("1/2 done")).toBeInTheDocument();
+  });
+
+  it("shows Today's Progress label", () => {
+    render(<ScorecardSummary routines={[]} checkIns={new Map()} />);
+    expect(screen.getByText("Today's Progress")).toBeInTheDocument();
+  });
+
+  it("shows tag breakdown counts", () => {
+    const routines = [
+      makeRoutine({ id: "r1", tag: "positive" }),
+      makeRoutine({ id: "r2", tag: "positive" }),
+      makeRoutine({ id: "r3", tag: "negative" }),
+      makeRoutine({ id: "r4", tag: "neutral" }),
+    ];
+    render(<ScorecardSummary routines={routines} checkIns={new Map()} />);
+    expect(screen.getByText("2 positive")).toBeInTheDocument();
+    expect(screen.getByText("1 negative")).toBeInTheDocument();
+    expect(screen.getByText("1 neutral")).toBeInTheDocument();
+  });
+
+  it("shows 0/0 done when no routines", () => {
+    render(<ScorecardSummary routines={[]} checkIns={new Map()} />);
+    expect(screen.getByText("0/0 done")).toBeInTheDocument();
+  });
+
+  it("counts only completed check-ins", () => {
+    const routines = [
+      makeRoutine({ id: "r1" }),
+      makeRoutine({ id: "r2" }),
+    ];
+    const checkIns = new Map<string, CheckIn>();
+    checkIns.set("r1", makeCheckIn({ routine_id: "r1", completed: true }));
+    checkIns.set("r2", makeCheckIn({ routine_id: "r2", completed: false }));
+
+    render(<ScorecardSummary routines={routines} checkIns={checkIns} />);
+    expect(screen.getByText("1/2 done")).toBeInTheDocument();
+  });
+});
+
+// ─── DateNavigator ───────────────────────────────────────
+
+describe("DateNavigator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 11)); // March 11, 2026
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows 'Today' when selected date is today", () => {
+    render(<DateNavigator selectedDate="2026-03-11" onDateChange={() => {}} />);
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("shows 'Yesterday' for previous day", () => {
+    render(<DateNavigator selectedDate="2026-03-10" onDateChange={() => {}} />);
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+  });
+
+  it("shows formatted date for other days", () => {
+    render(<DateNavigator selectedDate="2026-03-08" onDateChange={() => {}} />);
+    // Should not show "Yesterday" as the date label
+    expect(screen.queryByText("Yesterday")).not.toBeInTheDocument();
+    // "Today" appears as the jump button, not the date label — that's correct
+    // The date label should be a formatted date like "Sun, Mar 8"
+    expect(screen.getByText(/Mar/)).toBeInTheDocument();
+  });
+
+  it("calls onDateChange with previous day on left arrow", () => {
+    const onChange = vi.fn();
+    render(<DateNavigator selectedDate="2026-03-11" onDateChange={onChange} />);
+    fireEvent.click(screen.getByLabelText("Previous day"));
+    expect(onChange).toHaveBeenCalledWith("2026-03-10");
+  });
+
+  it("calls onDateChange with next day on right arrow", () => {
+    const onChange = vi.fn();
+    render(<DateNavigator selectedDate="2026-03-10" onDateChange={onChange} />);
+    fireEvent.click(screen.getByLabelText("Next day"));
+    expect(onChange).toHaveBeenCalledWith("2026-03-11");
+  });
+
+  it("disables next button when on today", () => {
+    render(<DateNavigator selectedDate="2026-03-11" onDateChange={() => {}} />);
+    expect(screen.getByLabelText("Next day")).toBeDisabled();
+  });
+
+  it("shows Today button when not on today", () => {
+    render(<DateNavigator selectedDate="2026-03-09" onDateChange={() => {}} />);
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("hides Today button when on today", () => {
+    render(<DateNavigator selectedDate="2026-03-11" onDateChange={() => {}} />);
+    // "Today" appears as the date label, not as a separate button
+    const todayElements = screen.getAllByText("Today");
+    expect(todayElements).toHaveLength(1); // only the date label
+  });
+});
+
+// ─── RoutineItem ─────────────────────────────────────────
+
+describe("RoutineItem", () => {
+  const defaultProps = {
+    routine: makeRoutine({ id: "r1", name: "Exercise", tag: "positive" }),
+    completed: false,
+    onToggle: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultProps.onToggle = vi.fn();
+    defaultProps.onEdit = vi.fn();
+    defaultProps.onDelete = vi.fn();
+  });
+
+  it("renders routine name", () => {
+    render(<RoutineItem {...defaultProps} />);
+    expect(screen.getByText("Exercise")).toBeInTheDocument();
+  });
+
+  it("renders tag badge", () => {
+    render(<RoutineItem {...defaultProps} />);
+    expect(screen.getByText("+")).toBeInTheDocument();
+  });
+
+  it("calls onToggle when checkbox is clicked", () => {
+    render(<RoutineItem {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/Mark Exercise as done/));
+    expect(defaultProps.onToggle).toHaveBeenCalledWith("r1");
+  });
+
+  it("shows strikethrough when completed", () => {
+    render(<RoutineItem {...defaultProps} completed={true} />);
+    const name = screen.getByText("Exercise");
+    expect(name.className).toContain("line-through");
+  });
+
+  it("does not show strikethrough when not completed", () => {
+    render(<RoutineItem {...defaultProps} completed={false} />);
+    const name = screen.getByText("Exercise");
+    expect(name.className).not.toContain("line-through");
+  });
+
+  it("opens menu on kebab click", () => {
+    render(<RoutineItem {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/Options for Exercise/));
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Edit is clicked", () => {
+    render(<RoutineItem {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/Options for Exercise/));
+    fireEvent.click(screen.getByText("Edit"));
+    expect(defaultProps.onEdit).toHaveBeenCalledWith(defaultProps.routine);
+  });
+
+  it("calls onDelete when Delete is clicked", () => {
+    render(<RoutineItem {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/Options for Exercise/));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(defaultProps.onDelete).toHaveBeenCalledWith("r1");
+  });
+
+  it("renders negative tag badge", () => {
+    const routine = makeRoutine({ tag: "negative" });
+    render(<RoutineItem {...defaultProps} routine={routine} />);
+    expect(screen.getByText("−")).toBeInTheDocument();
+  });
+
+  it("renders neutral tag badge", () => {
+    const routine = makeRoutine({ tag: "neutral" });
+    render(<RoutineItem {...defaultProps} routine={routine} />);
+    expect(screen.getByText("=")).toBeInTheDocument();
+  });
+});
+
+// ─── RoutineGroup ────────────────────────────────────────
+
+describe("RoutineGroup", () => {
+  const defaultProps = {
+    label: "Morning",
+    routines: [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Stretch" }),
+    ],
+    checkIns: new Map<string, CheckIn>(),
+    onToggle: vi.fn(),
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  it("renders group label", () => {
+    render(<RoutineGroup {...defaultProps} />);
+    expect(screen.getByText("Morning")).toBeInTheDocument();
+  });
+
+  it("renders all routines in the group", () => {
+    render(<RoutineGroup {...defaultProps} />);
+    expect(screen.getByText("Coffee")).toBeInTheDocument();
+    expect(screen.getByText("Stretch")).toBeInTheDocument();
+  });
+
+  it("renders nothing when routines array is empty", () => {
+    const { container } = render(
+      <RoutineGroup {...defaultProps} routines={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("passes completed state from checkIns map", () => {
+    const checkIns = new Map<string, CheckIn>();
+    checkIns.set("r1", makeCheckIn({ routine_id: "r1", completed: true }));
+
+    render(<RoutineGroup {...defaultProps} checkIns={checkIns} />);
+    // Coffee's name should have line-through (completed)
+    const coffee = screen.getByText("Coffee");
+    expect(coffee.className).toContain("line-through");
+    // Stretch should not (no check-in)
+    const stretch = screen.getByText("Stretch");
+    expect(stretch.className).not.toContain("line-through");
+  });
+});
+
+// ─── AddRoutineForm ──────────────────────────────────────
+
+describe("AddRoutineForm", () => {
+  it("renders form fields", () => {
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText("Routine name")).toBeInTheDocument();
+    expect(screen.getByText("How does this habit affect you?")).toBeInTheDocument();
+    expect(screen.getByText("When do you usually do this?")).toBeInTheDocument();
+  });
+
+  it("shows Add Routine button in create mode", () => {
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText("Add Routine")).toBeInTheDocument();
+  });
+
+  it("shows Save Changes button in edit mode", () => {
+    const routine = makeRoutine({ name: "Exercise" });
+    render(
+      <AddRoutineForm routine={routine} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText("Save Changes")).toBeInTheDocument();
+  });
+
+  it("pre-fills name in edit mode", () => {
+    const routine = makeRoutine({ name: "Exercise" });
+    render(
+      <AddRoutineForm routine={routine} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByDisplayValue("Exercise")).toBeInTheDocument();
+  });
+
+  it("renders all tag options", () => {
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText("Positive (+)")).toBeInTheDocument();
+    expect(screen.getByText("Negative (−)")).toBeInTheDocument();
+    expect(screen.getByText("Neutral (=)")).toBeInTheDocument();
+  });
+
+  it("renders all time of day options", () => {
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText("Morning")).toBeInTheDocument();
+    expect(screen.getByText("Afternoon")).toBeInTheDocument();
+    expect(screen.getByText("Evening")).toBeInTheDocument();
+    expect(screen.getByText("Night")).toBeInTheDocument();
+    expect(screen.getByText("No time")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("allows selecting a tag", () => {
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
+    );
+    const positiveBtn = screen.getByText("Positive (+)");
+    fireEvent.click(positiveBtn);
+    // After click, the button should have the active class
+    expect(positiveBtn.className).toContain("border-positive");
+  });
+
+  it("allows selecting a time of day", () => {
+    render(
+      <AddRoutineForm onSubmit={async () => {}} onClose={() => {}} />
+    );
+    const morningBtn = screen.getByText("Morning");
+    fireEvent.click(morningBtn);
+    expect(morningBtn.className).toContain("border-primary");
+  });
+
+  it("calls onSubmit with form data and closes on success", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(<AddRoutineForm onSubmit={onSubmit} onClose={onClose} />);
+
+    // Fill in name
+    fireEvent.change(screen.getByPlaceholderText(/Brush teeth/), {
+      target: { value: "Exercise" },
+    });
+    // Select tag
+    fireEvent.click(screen.getByText("Positive (+)"));
+    // Select time
+    fireEvent.click(screen.getByText("Morning"));
+    // Submit
+    fireEvent.click(screen.getByText("Add Routine"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: "Exercise",
+        tag: "positive",
+        time_of_day: "morning",
+      });
+    });
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error when submitting empty name", async () => {
+    const onSubmit = vi.fn();
+    render(<AddRoutineForm onSubmit={onSubmit} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByText("Add Routine"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Name is required")).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows error when onSubmit rejects", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("Server error"));
+    render(<AddRoutineForm onSubmit={onSubmit} onClose={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Brush teeth/), {
+      target: { value: "Exercise" },
+    });
+    fireEvent.click(screen.getByText("Add Routine"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Server error")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/stacks/__tests__/stacks.test.tsx
+++ b/src/components/stacks/__tests__/stacks.test.tsx
@@ -85,11 +85,25 @@ describe("StackCard", () => {
       ...makeChain(),
       steps: [
         {
-          stack: { id: "s1", user_id: "u1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "" },
+          stack: {
+            id: "s1",
+            user_id: "u1",
+            anchor_routine_id: "r1",
+            stacked_routine_id: "r2",
+            position: 0,
+            created_at: "",
+          },
           routine: makeRoutine({ id: "r2", name: "Journal" }),
         },
         {
-          stack: { id: "s2", user_id: "u1", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1, created_at: "" },
+          stack: {
+            id: "s2",
+            user_id: "u1",
+            anchor_routine_id: "r1",
+            stacked_routine_id: "r3",
+            position: 1,
+            created_at: "",
+          },
           routine: makeRoutine({ id: "r3", name: "Stretch" }),
         },
       ],
@@ -111,7 +125,11 @@ describe("StackBuilder", () => {
 
   it("renders anchor picker with routine names", () => {
     render(
-      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     expect(screen.getByText("Morning coffee")).toBeInTheDocument();
     expect(screen.getByText("Read 10 pages")).toBeInTheDocument();
@@ -120,10 +138,16 @@ describe("StackBuilder", () => {
 
   it("shows step 2 after anchor is selected", () => {
     render(
-      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     // Step 2 shouldn't be visible yet
-    expect(screen.queryByText("2. Stack a habit on top")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("2. Stack a habit on top")
+    ).not.toBeInTheDocument();
 
     // Select anchor
     fireEvent.click(screen.getByText("Morning coffee"));
@@ -134,7 +158,11 @@ describe("StackBuilder", () => {
 
   it("filters stacked picker to exclude selected anchor", () => {
     render(
-      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     // Select anchor
     fireEvent.click(screen.getByText("Morning coffee"));
@@ -151,7 +179,11 @@ describe("StackBuilder", () => {
 
   it("shows preview when both anchor and stacked are selected", () => {
     render(
-      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     // Select anchor
     fireEvent.click(screen.getByText("Morning coffee"));
@@ -166,7 +198,11 @@ describe("StackBuilder", () => {
   it("calls onClose when Cancel is clicked", () => {
     const onClose = vi.fn();
     render(
-      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={onClose} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={async () => {}}
+        onClose={onClose}
+      />
     );
     fireEvent.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalledOnce();
@@ -174,7 +210,11 @@ describe("StackBuilder", () => {
 
   it("shows empty state when no routines", () => {
     render(
-      <StackBuilder routines={[]} onSubmit={async () => {}} onClose={() => {}} />
+      <StackBuilder
+        routines={[]}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     expect(screen.getByText(/No routines yet/)).toBeInTheDocument();
   });
@@ -208,7 +248,11 @@ describe("StackBuilder", () => {
 
   it("switches to new routine mode and shows form fields", () => {
     render(
-      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={async () => {}}
+        onClose={() => {}}
+      />
     );
     // Select anchor first
     fireEvent.click(screen.getByText("Morning coffee"));
@@ -254,7 +298,11 @@ describe("StackBuilder", () => {
   it("shows error when onSubmit rejects", async () => {
     const onSubmit = vi.fn().mockRejectedValue(new Error("Failed to create"));
     render(
-      <StackBuilder routines={routines} onSubmit={onSubmit} onClose={() => {}} />
+      <StackBuilder
+        routines={routines}
+        onSubmit={onSubmit}
+        onClose={() => {}}
+      />
     );
 
     fireEvent.click(screen.getByText("Morning coffee"));

--- a/src/components/stacks/__tests__/stacks.test.tsx
+++ b/src/components/stacks/__tests__/stacks.test.tsx
@@ -1,0 +1,269 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { StackCard } from "../StackCard";
+import { StackBuilder } from "../StackBuilder";
+import type { StackChain } from "@/types/stacks";
+import type { Routine } from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "u1",
+    name: "Test Routine",
+    tag: "positive",
+    time_of_day: "morning",
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeChain(): StackChain {
+  return {
+    anchor: makeRoutine({ id: "r1", name: "Morning coffee", tag: "neutral" }),
+    steps: [
+      {
+        stack: {
+          id: "s1",
+          user_id: "u1",
+          anchor_routine_id: "r1",
+          stacked_routine_id: "r2",
+          position: 0,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+        routine: makeRoutine({ id: "r2", name: "Journal", tag: "positive" }),
+      },
+    ],
+  };
+}
+
+// ─── StackCard ───────────────────────────────────────────
+
+describe("StackCard", () => {
+  it("renders anchor routine name", () => {
+    render(<StackCard chain={makeChain()} onDelete={() => {}} />);
+    expect(screen.getByText("Morning coffee")).toBeInTheDocument();
+  });
+
+  it("renders stacked routine name", () => {
+    render(<StackCard chain={makeChain()} onDelete={() => {}} />);
+    expect(screen.getByText("Journal")).toBeInTheDocument();
+  });
+
+  it("shows ANCHOR and STACKED labels", () => {
+    render(<StackCard chain={makeChain()} onDelete={() => {}} />);
+    expect(screen.getByText("ANCHOR")).toBeInTheDocument();
+    expect(screen.getByText("STACKED")).toBeInTheDocument();
+  });
+
+  it("shows connector text", () => {
+    render(<StackCard chain={makeChain()} onDelete={() => {}} />);
+    expect(screen.getByText("then I will...")).toBeInTheDocument();
+  });
+
+  it("opens menu on kebab button click", () => {
+    render(<StackCard chain={makeChain()} onDelete={() => {}} />);
+    fireEvent.click(screen.getByLabelText("Stack options"));
+    expect(screen.getByText("Delete stack")).toBeInTheDocument();
+  });
+
+  it("calls onDelete with stack id when delete is clicked", () => {
+    const onDelete = vi.fn();
+    render(<StackCard chain={makeChain()} onDelete={onDelete} />);
+    fireEvent.click(screen.getByLabelText("Stack options"));
+    fireEvent.click(screen.getByText("Delete stack"));
+    expect(onDelete).toHaveBeenCalledWith("s1");
+  });
+
+  it("renders multiple steps in a chain", () => {
+    const chain: StackChain = {
+      ...makeChain(),
+      steps: [
+        {
+          stack: { id: "s1", user_id: "u1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "" },
+          routine: makeRoutine({ id: "r2", name: "Journal" }),
+        },
+        {
+          stack: { id: "s2", user_id: "u1", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1, created_at: "" },
+          routine: makeRoutine({ id: "r3", name: "Stretch" }),
+        },
+      ],
+    };
+    render(<StackCard chain={chain} onDelete={() => {}} />);
+    expect(screen.getByText("Journal")).toBeInTheDocument();
+    expect(screen.getByText("Stretch")).toBeInTheDocument();
+  });
+});
+
+// ─── StackBuilder ────────────────────────────────────────
+
+describe("StackBuilder", () => {
+  const routines = [
+    makeRoutine({ id: "r1", name: "Morning coffee", tag: "neutral" }),
+    makeRoutine({ id: "r2", name: "Read 10 pages", tag: "positive" }),
+    makeRoutine({ id: "r3", name: "Exercise", tag: "positive" }),
+  ];
+
+  it("renders anchor picker with routine names", () => {
+    render(
+      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText("Morning coffee")).toBeInTheDocument();
+    expect(screen.getByText("Read 10 pages")).toBeInTheDocument();
+    expect(screen.getByText("Exercise")).toBeInTheDocument();
+  });
+
+  it("shows step 2 after anchor is selected", () => {
+    render(
+      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    // Step 2 shouldn't be visible yet
+    expect(screen.queryByText("2. Stack a habit on top")).not.toBeInTheDocument();
+
+    // Select anchor
+    fireEvent.click(screen.getByText("Morning coffee"));
+
+    // Step 2 should now appear
+    expect(screen.getByText("2. Stack a habit on top")).toBeInTheDocument();
+  });
+
+  it("filters stacked picker to exclude selected anchor", () => {
+    render(
+      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    // Select anchor
+    fireEvent.click(screen.getByText("Morning coffee"));
+
+    // In the stacked picker, Morning coffee should NOT appear
+    // But Read 10 pages and Exercise should
+    const buttons = screen.getAllByText("Read 10 pages");
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+
+    // Morning coffee appears once (in the anchor list), not in stacked
+    const coffeeButtons = screen.getAllByText("Morning coffee");
+    expect(coffeeButtons).toHaveLength(1);
+  });
+
+  it("shows preview when both anchor and stacked are selected", () => {
+    render(
+      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    // Select anchor
+    fireEvent.click(screen.getByText("Morning coffee"));
+    // Select stacked — multiple "Read 10 pages" exist (anchor list + stacked list)
+    const readButtons = screen.getAllByText("Read 10 pages");
+    fireEvent.click(readButtons[readButtons.length - 1]);
+
+    // Preview should show
+    expect(screen.getByText(/After I/)).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows empty state when no routines", () => {
+    render(
+      <StackBuilder routines={[]} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    expect(screen.getByText(/No routines yet/)).toBeInTheDocument();
+  });
+
+  it("calls onSubmit with existing mode data and closes", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <StackBuilder routines={routines} onSubmit={onSubmit} onClose={onClose} />
+    );
+
+    // Select anchor
+    fireEvent.click(screen.getByText("Morning coffee"));
+    // Select stacked
+    const readButtons = screen.getAllByText("Read 10 pages");
+    fireEvent.click(readButtons[readButtons.length - 1]);
+    // Submit
+    fireEvent.click(screen.getByText("Create Stack"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        mode: "existing",
+        anchorRoutineId: "r1",
+        stackedRoutineId: "r2",
+      });
+    });
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("switches to new routine mode and shows form fields", () => {
+    render(
+      <StackBuilder routines={routines} onSubmit={async () => {}} onClose={() => {}} />
+    );
+    // Select anchor first
+    fireEvent.click(screen.getByText("Morning coffee"));
+    // Switch to "Create new" mode
+    fireEvent.click(screen.getByText("Create new"));
+
+    expect(screen.getByText("Habit name")).toBeInTheDocument();
+    expect(screen.getByText("Tag")).toBeInTheDocument();
+    expect(screen.getByText("Time of day")).toBeInTheDocument();
+  });
+
+  it("calls onSubmit with new mode data", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <StackBuilder routines={routines} onSubmit={onSubmit} onClose={onClose} />
+    );
+
+    // Select anchor
+    fireEvent.click(screen.getByText("Morning coffee"));
+    // Switch to new mode
+    fireEvent.click(screen.getByText("Create new"));
+    // Fill in new routine
+    fireEvent.change(screen.getByPlaceholderText(/Journal 2 min/), {
+      target: { value: "Stretch" },
+    });
+    // Submit
+    fireEvent.click(screen.getByText("Create Stack"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        mode: "new",
+        anchorRoutineId: "r1",
+        newRoutine: {
+          name: "Stretch",
+          tag: "positive",
+          time_of_day: null,
+        },
+      });
+    });
+  });
+
+  it("shows error when onSubmit rejects", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("Failed to create"));
+    render(
+      <StackBuilder routines={routines} onSubmit={onSubmit} onClose={() => {}} />
+    );
+
+    fireEvent.click(screen.getByText("Morning coffee"));
+    const readButtons = screen.getAllByText("Read 10 pages");
+    fireEvent.click(readButtons[readButtons.length - 1]);
+    fireEvent.click(screen.getByText("Create Stack"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to create")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/__tests__/ui.test.tsx
+++ b/src/components/ui/__tests__/ui.test.tsx
@@ -1,0 +1,181 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Button } from "../Button";
+import { Input } from "../Input";
+import { Card } from "../Card";
+import { Modal } from "../Modal";
+
+// ─── Button ──────────────────────────────────────────────
+
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+  });
+
+  it("shows loading spinner when loading", () => {
+    render(<Button loading>Save</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    // Loader2 renders as an svg
+    expect(button.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(<Button disabled>Submit</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("calls onClick handler", () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Go</Button>);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("applies primary variant styles by default", () => {
+    render(<Button>Primary</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("bg-indigo-500");
+  });
+
+  it("applies danger variant styles", () => {
+    render(<Button variant="danger">Delete</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("text-white");
+  });
+
+  it("applies fullWidth class", () => {
+    render(<Button fullWidth>Wide</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("w-full");
+  });
+});
+
+// ─── Input ───────────────────────────────────────────────
+
+describe("Input", () => {
+  it("renders label", () => {
+    render(<Input label="Email" />);
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("renders input element", () => {
+    render(<Input label="Name" placeholder="Enter name" />);
+    expect(screen.getByPlaceholderText("Enter name")).toBeInTheDocument();
+  });
+
+  it("shows error message", () => {
+    render(<Input label="Email" error="Invalid email" />);
+    expect(screen.getByText("Invalid email")).toBeInTheDocument();
+  });
+
+  it("applies disabled state", () => {
+    render(<Input label="Name" disabled />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("calls onChange handler", () => {
+    const onChange = vi.fn();
+    render(<Input label="Name" onChange={onChange} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "test" } });
+    expect(onChange).toHaveBeenCalled();
+  });
+});
+
+// ─── Card ────────────────────────────────────────────────
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<Card className="my-custom">Content</Card>);
+    expect(container.firstChild).toHaveClass("my-custom");
+  });
+
+  it("has base card styles", () => {
+    const { container } = render(<Card>Content</Card>);
+    expect(container.firstChild).toHaveClass("rounded-2xl");
+    expect(container.firstChild).toHaveClass("bg-white");
+  });
+});
+
+// ─── Modal ───────────────────────────────────────────────
+
+describe("Modal", () => {
+  it("renders nothing when isOpen is false", () => {
+    render(
+      <Modal isOpen={false} onClose={() => {}}>
+        Hidden content
+      </Modal>
+    );
+    expect(screen.queryByText("Hidden content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when isOpen is true", () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}}>
+        Modal content
+      </Modal>
+    );
+    expect(screen.getByText("Modal content")).toBeInTheDocument();
+  });
+
+  it("renders title when provided", () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} title="My Modal">
+        Content
+      </Modal>
+    );
+    expect(screen.getByText("My Modal")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={onClose} title="Test">
+        Content
+      </Modal>
+    );
+    fireEvent.click(screen.getByLabelText("Close modal"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        Content
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        Content
+      </Modal>
+    );
+    // The backdrop has aria-hidden="true"
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop!);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("has role dialog", () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}}>
+        Content
+      </Modal>
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/__tests__/ui.test.tsx
+++ b/src/components/ui/__tests__/ui.test.tsx
@@ -11,7 +11,9 @@ import { Modal } from "../Modal";
 describe("Button", () => {
   it("renders children", () => {
     render(<Button>Click me</Button>);
-    expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Click me" })
+    ).toBeInTheDocument();
   });
 
   it("shows loading spinner when loading", () => {
@@ -79,7 +81,9 @@ describe("Input", () => {
   it("calls onChange handler", () => {
     const onChange = vi.fn();
     render(<Input label="Name" onChange={onChange} />);
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "test" } });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "test" },
+    });
     expect(onChange).toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/hooks.integration.test.ts
+++ b/src/hooks/__tests__/hooks.integration.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+// ─── Mock Supabase before importing hooks ────────────────
+
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+// Import hooks AFTER mock is set up
+import { useRoutines } from "../useRoutines";
+import { useCheckIns } from "../useCheckIns";
+import { useStacks } from "../useStacks";
+import { useIdentities } from "../useIdentities";
+import { usePartners } from "../usePartners";
+
+// ─── Query builder factory ───────────────────────────────
+
+/**
+ * Creates a chainable mock that resolves with { data, error }.
+ * Every method returns `this` for chaining, and it's thenable.
+ */
+function createChainableQuery(data: unknown = [], error: unknown = null) {
+  const resolved = { data, error };
+  const builder: Record<string, unknown> = {};
+
+  const chainMethods = [
+    "select", "eq", "neq", "in", "is", "or", "not",
+    "order", "limit", "filter", "match",
+    "gt", "gte", "lt", "lte",
+    "insert", "update", "delete", "upsert",
+  ];
+
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockReturnValue(builder);
+  });
+
+  builder.single = vi.fn().mockResolvedValue(resolved);
+
+  // Make builder thenable
+  builder.then = (resolve: (v: unknown) => void, reject?: (r: unknown) => void) =>
+    Promise.resolve(resolved).then(resolve, reject);
+
+  return builder;
+}
+
+// ─── Helpers ─────────────────────────────────────────────
+
+const testUser = {
+  id: "user-1",
+  email: "test@example.com",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function mockAuthenticatedUser() {
+  mockGetUser.mockResolvedValue({ data: { user: testUser }, error: null });
+}
+
+function mockUnauthenticatedUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+/**
+ * Configure mockFrom to return specific data per table.
+ * Accepts a map of table name → data array.
+ */
+function setupTableMocks(tables: Record<string, unknown[]>) {
+  mockFrom.mockImplementation((table: string) => {
+    const data = tables[table] ?? [];
+    return createChainableQuery(data);
+  });
+}
+
+// ─── Reset ───────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticatedUser();
+});
+
+// ─── useRoutines ─────────────────────────────────────────
+
+describe("useRoutines", () => {
+  it("starts in loading state", () => {
+    setupTableMocks({ routines: [] });
+    const { result } = renderHook(() => useRoutines());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("fetches routines on mount", async () => {
+    const routines = [
+      { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    ];
+    setupTableMocks({ routines });
+
+    const { result } = renderHook(() => useRoutines());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.routines).toHaveLength(1);
+    expect(result.current.routines[0].name).toBe("Coffee");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns empty array when not authenticated", async () => {
+    mockUnauthenticatedUser();
+    setupTableMocks({ routines: [] });
+
+    const { result } = renderHook(() => useRoutines());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.routines).toHaveLength(0);
+  });
+});
+
+// ─── useCheckIns ─────────────────────────────────────────
+
+describe("useCheckIns", () => {
+  it("fetches check-ins for the given date", async () => {
+    const checkIns = [
+      { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: true, created_at: "2026-03-11", updated_at: "2026-03-11" },
+    ];
+    setupTableMocks({ check_ins: checkIns });
+
+    const { result } = renderHook(() => useCheckIns("2026-03-11"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.checkIns.size).toBe(1);
+    expect(result.current.checkIns.get("r1")?.completed).toBe(true);
+  });
+
+  it("getCompletionStats calculates correctly", async () => {
+    const checkIns = [
+      { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: true, created_at: "2026-03-11", updated_at: "2026-03-11" },
+      { id: "c2", user_id: "user-1", routine_id: "r2", date: "2026-03-11", completed: false, created_at: "2026-03-11", updated_at: "2026-03-11" },
+    ];
+    setupTableMocks({ check_ins: checkIns });
+
+    const { result } = renderHook(() => useCheckIns("2026-03-11"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const stats = result.current.getCompletionStats(4);
+    expect(stats.completed).toBe(1);
+    expect(stats.total).toBe(4);
+    expect(stats.percentage).toBe(25);
+  });
+
+  it("getCompletionStats returns 0% with zero routines", async () => {
+    setupTableMocks({ check_ins: [] });
+
+    const { result } = renderHook(() => useCheckIns("2026-03-11"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const stats = result.current.getCompletionStats(0);
+    expect(stats.percentage).toBe(0);
+  });
+});
+
+// ─── useStacks ───────────────────────────────────────────
+
+describe("useStacks", () => {
+  it("fetches stacks and routines in parallel", async () => {
+    const routines = [
+      { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+      { id: "r2", user_id: "user-1", name: "Journal", tag: "positive", time_of_day: "morning", sort_order: 1, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    ];
+    const stacks = [
+      { id: "s1", user_id: "user-1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "2026-01-01" },
+    ];
+
+    setupTableMocks({ habit_stacks: stacks, routines });
+
+    const { result } = renderHook(() => useStacks());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chains).toHaveLength(1);
+    expect(result.current.chains[0].anchor.name).toBe("Coffee");
+    expect(result.current.chains[0].steps[0].routine.name).toBe("Journal");
+    expect(result.current.routines).toHaveLength(2);
+  });
+
+  it("returns empty chains when not authenticated", async () => {
+    mockUnauthenticatedUser();
+    setupTableMocks({});
+
+    const { result } = renderHook(() => useStacks());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chains).toHaveLength(0);
+    expect(result.current.routines).toHaveLength(0);
+  });
+});
+
+// ─── useIdentities ───────────────────────────────────────
+
+describe("useIdentities", () => {
+  it("fetches and enriches identities with vote data", async () => {
+    const identities = [
+      { id: "i1", user_id: "user-1", statement: "I am a reader", archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    ];
+    const identityHabits = [
+      { id: "ih1", identity_id: "i1", routine_id: "r1", user_id: "user-1" },
+    ];
+    const routines = [
+      { id: "r1", user_id: "user-1", name: "Read", tag: "positive", time_of_day: "evening", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    ];
+    const checkIns = [
+      { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: true, created_at: "2026-03-11", updated_at: "2026-03-11" },
+    ];
+
+    setupTableMocks({
+      identities,
+      identity_habits: identityHabits,
+      routines,
+      check_ins: checkIns,
+    });
+
+    const { result } = renderHook(() => useIdentities());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.identities).toHaveLength(1);
+    expect(result.current.identities[0].statement).toBe("I am a reader");
+    expect(result.current.identities[0].linked_routines).toHaveLength(1);
+    expect(result.current.identities[0].total_votes).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns empty when not authenticated", async () => {
+    mockUnauthenticatedUser();
+    setupTableMocks({});
+
+    const { result } = renderHook(() => useIdentities());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.identities).toHaveLength(0);
+  });
+});
+
+// ─── usePartners ─────────────────────────────────────────
+
+describe("usePartners", () => {
+  it("fetches partnerships and nudges on mount", async () => {
+    const partnerships = [
+      { id: "p1", requester_id: "user-1", partner_id: "user-2", invite_token: "tok", invite_email: null, status: "active", created_at: "2026-03-01", updated_at: "2026-03-01" },
+    ];
+    const nudges = [
+      { id: "n1", partnership_id: "p1", sender_id: "user-2", receiver_id: "user-1", message: "Keep going!", read: false, created_at: "2026-03-11" },
+    ];
+    const profiles = [
+      { id: "user-2", display_name: "Partner Person" },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "partnerships") return createChainableQuery(partnerships);
+      if (table === "nudges") return createChainableQuery(nudges);
+      if (table === "profiles") return createChainableQuery(profiles);
+      return createChainableQuery([]);
+    });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.partnerships).toHaveLength(1);
+    expect(result.current.partnerships[0].partner_profile.display_name).toBe("Partner Person");
+    expect(result.current.unreadNudgeCount).toBe(1);
+    expect(result.current.nudges).toHaveLength(1);
+  });
+
+  it("returns empty state when not authenticated", async () => {
+    mockUnauthenticatedUser();
+    setupTableMocks({});
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.partnerships).toHaveLength(0);
+    expect(result.current.nudges).toHaveLength(0);
+    expect(result.current.unreadNudgeCount).toBe(0);
+  });
+
+  it("separates active partnerships from pending invites", async () => {
+    const partnerships = [
+      { id: "p1", requester_id: "user-2", partner_id: "user-1", invite_token: "tok1", invite_email: null, status: "active", created_at: "2026-03-01", updated_at: "2026-03-01" },
+      { id: "p2", requester_id: "user-3", partner_id: "user-1", invite_token: "tok2", invite_email: null, status: "pending", created_at: "2026-03-10", updated_at: "2026-03-10" },
+    ];
+    const profiles = [
+      { id: "user-2", display_name: "Active Partner" },
+      { id: "user-3", display_name: "Pending Person" },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "partnerships") return createChainableQuery(partnerships);
+      if (table === "profiles") return createChainableQuery(profiles);
+      if (table === "nudges") return createChainableQuery([]);
+      return createChainableQuery([]);
+    });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.partnerships).toHaveLength(1);
+    expect(result.current.partnerships[0].partner_profile.display_name).toBe("Active Partner");
+    expect(result.current.pendingInvites).toHaveLength(1);
+    expect(result.current.pendingInvites[0].partner_profile.display_name).toBe("Pending Person");
+  });
+});

--- a/src/hooks/__tests__/hooks.integration.test.ts
+++ b/src/hooks/__tests__/hooks.integration.test.ts
@@ -31,10 +31,25 @@ function createChainableQuery(data: unknown = [], error: unknown = null) {
   const builder: Record<string, unknown> = {};
 
   const chainMethods = [
-    "select", "eq", "neq", "in", "is", "or", "not",
-    "order", "limit", "filter", "match",
-    "gt", "gte", "lt", "lte",
-    "insert", "update", "delete", "upsert",
+    "select",
+    "eq",
+    "neq",
+    "in",
+    "is",
+    "or",
+    "not",
+    "order",
+    "limit",
+    "filter",
+    "match",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "insert",
+    "update",
+    "delete",
+    "upsert",
   ];
 
   chainMethods.forEach((m) => {
@@ -44,8 +59,10 @@ function createChainableQuery(data: unknown = [], error: unknown = null) {
   builder.single = vi.fn().mockResolvedValue(resolved);
 
   // Make builder thenable
-  builder.then = (resolve: (v: unknown) => void, reject?: (r: unknown) => void) =>
-    Promise.resolve(resolved).then(resolve, reject);
+  builder.then = (
+    resolve: (v: unknown) => void,
+    reject?: (r: unknown) => void
+  ) => Promise.resolve(resolved).then(resolve, reject);
 
   return builder;
 }
@@ -98,7 +115,17 @@ describe("useRoutines", () => {
 
   it("fetches routines on mount", async () => {
     const routines = [
-      { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+      {
+        id: "r1",
+        user_id: "user-1",
+        name: "Coffee",
+        tag: "neutral",
+        time_of_day: "morning",
+        sort_order: 0,
+        archived_at: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
     ];
     setupTableMocks({ routines });
 
@@ -132,7 +159,15 @@ describe("useRoutines", () => {
 describe("useCheckIns", () => {
   it("fetches check-ins for the given date", async () => {
     const checkIns = [
-      { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: true, created_at: "2026-03-11", updated_at: "2026-03-11" },
+      {
+        id: "c1",
+        user_id: "user-1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+        created_at: "2026-03-11",
+        updated_at: "2026-03-11",
+      },
     ];
     setupTableMocks({ check_ins: checkIns });
 
@@ -148,8 +183,24 @@ describe("useCheckIns", () => {
 
   it("getCompletionStats calculates correctly", async () => {
     const checkIns = [
-      { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: true, created_at: "2026-03-11", updated_at: "2026-03-11" },
-      { id: "c2", user_id: "user-1", routine_id: "r2", date: "2026-03-11", completed: false, created_at: "2026-03-11", updated_at: "2026-03-11" },
+      {
+        id: "c1",
+        user_id: "user-1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+        created_at: "2026-03-11",
+        updated_at: "2026-03-11",
+      },
+      {
+        id: "c2",
+        user_id: "user-1",
+        routine_id: "r2",
+        date: "2026-03-11",
+        completed: false,
+        created_at: "2026-03-11",
+        updated_at: "2026-03-11",
+      },
     ];
     setupTableMocks({ check_ins: checkIns });
 
@@ -184,11 +235,38 @@ describe("useCheckIns", () => {
 describe("useStacks", () => {
   it("fetches stacks and routines in parallel", async () => {
     const routines = [
-      { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
-      { id: "r2", user_id: "user-1", name: "Journal", tag: "positive", time_of_day: "morning", sort_order: 1, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+      {
+        id: "r1",
+        user_id: "user-1",
+        name: "Coffee",
+        tag: "neutral",
+        time_of_day: "morning",
+        sort_order: 0,
+        archived_at: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+      {
+        id: "r2",
+        user_id: "user-1",
+        name: "Journal",
+        tag: "positive",
+        time_of_day: "morning",
+        sort_order: 1,
+        archived_at: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
     ];
     const stacks = [
-      { id: "s1", user_id: "user-1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "2026-01-01" },
+      {
+        id: "s1",
+        user_id: "user-1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+        created_at: "2026-01-01",
+      },
     ];
 
     setupTableMocks({ habit_stacks: stacks, routines });
@@ -225,16 +303,41 @@ describe("useStacks", () => {
 describe("useIdentities", () => {
   it("fetches and enriches identities with vote data", async () => {
     const identities = [
-      { id: "i1", user_id: "user-1", statement: "I am a reader", archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+      {
+        id: "i1",
+        user_id: "user-1",
+        statement: "I am a reader",
+        archived_at: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
     ];
     const identityHabits = [
       { id: "ih1", identity_id: "i1", routine_id: "r1", user_id: "user-1" },
     ];
     const routines = [
-      { id: "r1", user_id: "user-1", name: "Read", tag: "positive", time_of_day: "evening", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+      {
+        id: "r1",
+        user_id: "user-1",
+        name: "Read",
+        tag: "positive",
+        time_of_day: "evening",
+        sort_order: 0,
+        archived_at: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
     ];
     const checkIns = [
-      { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: true, created_at: "2026-03-11", updated_at: "2026-03-11" },
+      {
+        id: "c1",
+        user_id: "user-1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+        created_at: "2026-03-11",
+        updated_at: "2026-03-11",
+      },
     ];
 
     setupTableMocks({
@@ -275,14 +378,29 @@ describe("useIdentities", () => {
 describe("usePartners", () => {
   it("fetches partnerships and nudges on mount", async () => {
     const partnerships = [
-      { id: "p1", requester_id: "user-1", partner_id: "user-2", invite_token: "tok", invite_email: null, status: "active", created_at: "2026-03-01", updated_at: "2026-03-01" },
+      {
+        id: "p1",
+        requester_id: "user-1",
+        partner_id: "user-2",
+        invite_token: "tok",
+        invite_email: null,
+        status: "active",
+        created_at: "2026-03-01",
+        updated_at: "2026-03-01",
+      },
     ];
     const nudges = [
-      { id: "n1", partnership_id: "p1", sender_id: "user-2", receiver_id: "user-1", message: "Keep going!", read: false, created_at: "2026-03-11" },
+      {
+        id: "n1",
+        partnership_id: "p1",
+        sender_id: "user-2",
+        receiver_id: "user-1",
+        message: "Keep going!",
+        read: false,
+        created_at: "2026-03-11",
+      },
     ];
-    const profiles = [
-      { id: "user-2", display_name: "Partner Person" },
-    ];
+    const profiles = [{ id: "user-2", display_name: "Partner Person" }];
 
     mockFrom.mockImplementation((table: string) => {
       if (table === "partnerships") return createChainableQuery(partnerships);
@@ -298,7 +416,9 @@ describe("usePartners", () => {
     });
 
     expect(result.current.partnerships).toHaveLength(1);
-    expect(result.current.partnerships[0].partner_profile.display_name).toBe("Partner Person");
+    expect(result.current.partnerships[0].partner_profile.display_name).toBe(
+      "Partner Person"
+    );
     expect(result.current.unreadNudgeCount).toBe(1);
     expect(result.current.nudges).toHaveLength(1);
   });
@@ -320,8 +440,26 @@ describe("usePartners", () => {
 
   it("separates active partnerships from pending invites", async () => {
     const partnerships = [
-      { id: "p1", requester_id: "user-2", partner_id: "user-1", invite_token: "tok1", invite_email: null, status: "active", created_at: "2026-03-01", updated_at: "2026-03-01" },
-      { id: "p2", requester_id: "user-3", partner_id: "user-1", invite_token: "tok2", invite_email: null, status: "pending", created_at: "2026-03-10", updated_at: "2026-03-10" },
+      {
+        id: "p1",
+        requester_id: "user-2",
+        partner_id: "user-1",
+        invite_token: "tok1",
+        invite_email: null,
+        status: "active",
+        created_at: "2026-03-01",
+        updated_at: "2026-03-01",
+      },
+      {
+        id: "p2",
+        requester_id: "user-3",
+        partner_id: "user-1",
+        invite_token: "tok2",
+        invite_email: null,
+        status: "pending",
+        created_at: "2026-03-10",
+        updated_at: "2026-03-10",
+      },
     ];
     const profiles = [
       { id: "user-2", display_name: "Active Partner" },
@@ -342,8 +480,12 @@ describe("usePartners", () => {
     });
 
     expect(result.current.partnerships).toHaveLength(1);
-    expect(result.current.partnerships[0].partner_profile.display_name).toBe("Active Partner");
+    expect(result.current.partnerships[0].partner_profile.display_name).toBe(
+      "Active Partner"
+    );
     expect(result.current.pendingInvites).toHaveLength(1);
-    expect(result.current.pendingInvites[0].partner_profile.display_name).toBe("Pending Person");
+    expect(result.current.pendingInvites[0].partner_profile.display_name).toBe(
+      "Pending Person"
+    );
   });
 });

--- a/src/hooks/__tests__/hooks.mutations.test.ts
+++ b/src/hooks/__tests__/hooks.mutations.test.ts
@@ -1,0 +1,462 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+// ─── Mock Supabase ───────────────────────────────────────
+
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+import { useRoutines } from "../useRoutines";
+import { useCheckIns } from "../useCheckIns";
+import { useStacks } from "../useStacks";
+import { useIdentities } from "../useIdentities";
+import { usePartners } from "../usePartners";
+
+// ─── Query builder factory ───────────────────────────────
+
+function createChainableQuery(data: unknown = [], error: unknown = null) {
+  const resolved = { data, error };
+  const builder: Record<string, unknown> = {};
+
+  const chainMethods = [
+    "select", "eq", "neq", "in", "is", "or", "not",
+    "order", "limit", "filter", "match",
+    "gt", "gte", "lt", "lte",
+    "insert", "update", "delete", "upsert",
+  ];
+
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockReturnValue(builder);
+  });
+
+  builder.single = vi.fn().mockResolvedValue(resolved);
+
+  builder.then = (resolve: (v: unknown) => void, reject?: (r: unknown) => void) =>
+    Promise.resolve(resolved).then(resolve, reject);
+
+  return builder;
+}
+
+// ─── Helpers ─────────────────────────────────────────────
+
+const testUser = {
+  id: "user-1",
+  email: "test@example.com",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function mockAuth() {
+  mockGetUser.mockResolvedValue({ data: { user: testUser }, error: null });
+}
+
+function mockNoAuth() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setupTables(tables: Record<string, unknown[]>) {
+  mockFrom.mockImplementation((table: string) => {
+    const data = tables[table] ?? [];
+    return createChainableQuery(data);
+  });
+}
+
+// ─── Reset ───────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth();
+});
+
+// ─── useRoutines mutations ───────────────────────────────
+
+describe("useRoutines mutations", () => {
+  const routines = [
+    { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+  ];
+
+  it("addRoutine calls insert and refreshes", async () => {
+    setupTables({ routines });
+    const { result } = renderHook(() => useRoutines());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.addRoutine({ name: "Journal", tag: "positive", time_of_day: "morning" });
+    });
+
+    // from("routines").insert(...) should have been called
+    expect(mockFrom).toHaveBeenCalledWith("routines");
+  });
+
+  it("updateRoutine calls update and refreshes", async () => {
+    setupTables({ routines });
+    const { result } = renderHook(() => useRoutines());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateRoutine("r1", { name: "Updated Coffee" });
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("routines");
+  });
+
+  it("deleteRoutine calls update with archived_at and refreshes", async () => {
+    setupTables({ routines });
+    const { result } = renderHook(() => useRoutines());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.deleteRoutine("r1");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("routines");
+  });
+
+  it("addRoutine throws when not authenticated", async () => {
+    mockNoAuth();
+    setupTables({ routines: [] });
+    const { result } = renderHook(() => useRoutines());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Re-mock to no auth for the mutation call
+    mockNoAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.addRoutine({ name: "Test", tag: "positive" });
+      })
+    ).rejects.toThrow("Not authenticated");
+  });
+});
+
+// ─── useCheckIns mutations ───────────────────────────────
+
+describe("useCheckIns mutations", () => {
+  const checkIns = [
+    { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: false, created_at: "2026-03-11", updated_at: "2026-03-11" },
+  ];
+
+  it("toggleCheckIn flips existing check-in to completed", async () => {
+    setupTables({ check_ins: checkIns });
+    const { result } = renderHook(() => useCheckIns("2026-03-11"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.toggleCheckIn("r1");
+    });
+
+    // Should have called from("check_ins") for the update
+    expect(mockFrom).toHaveBeenCalledWith("check_ins");
+  });
+
+  it("toggleCheckIn creates new check-in when none exists", async () => {
+    setupTables({ check_ins: [] });
+    const { result } = renderHook(() => useCheckIns("2026-03-11"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.toggleCheckIn("r2");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("check_ins");
+  });
+
+  it("toggleCheckIn throws when not authenticated", async () => {
+    setupTables({ check_ins: [] });
+    const { result } = renderHook(() => useCheckIns("2026-03-11"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mockNoAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.toggleCheckIn("r1");
+      })
+    ).rejects.toThrow("Not authenticated");
+  });
+});
+
+// ─── useStacks mutations ─────────────────────────────────
+
+describe("useStacks mutations", () => {
+  const routines = [
+    { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    { id: "r2", user_id: "user-1", name: "Journal", tag: "positive", time_of_day: "morning", sort_order: 1, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+  ];
+  const stacks = [
+    { id: "s1", user_id: "user-1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "2026-01-01" },
+  ];
+
+  it("addStack calls insert and refreshes", async () => {
+    setupTables({ habit_stacks: stacks, routines });
+    const { result } = renderHook(() => useStacks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.addStack({
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+      });
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("habit_stacks");
+  });
+
+  it("deleteStack calls delete and refreshes", async () => {
+    setupTables({ habit_stacks: stacks, routines });
+    const { result } = renderHook(() => useStacks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.deleteStack("s1");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("habit_stacks");
+  });
+
+  it("addStack throws when not authenticated", async () => {
+    setupTables({ habit_stacks: [], routines: [] });
+    const { result } = renderHook(() => useStacks());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mockNoAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.addStack({
+          anchor_routine_id: "r1",
+          stacked_routine_id: "r2",
+        });
+      })
+    ).rejects.toThrow("Not authenticated");
+  });
+});
+
+// ─── useIdentities mutations ─────────────────────────────
+
+describe("useIdentities mutations", () => {
+  const identities = [
+    { id: "i1", user_id: "user-1", statement: "I am a reader", archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+  ];
+
+  it("addIdentity calls insert for identity and links", async () => {
+    // Need single() to return the new identity ID
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "identities") {
+        const builder = createChainableQuery(identities);
+        builder.single = vi.fn().mockResolvedValue({ data: { id: "i-new" }, error: null });
+        return builder;
+      }
+      return createChainableQuery([]);
+    });
+
+    const { result } = renderHook(() => useIdentities());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.addIdentity("I am healthy", ["r1"]);
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("identities");
+    expect(mockFrom).toHaveBeenCalledWith("identity_habits");
+  });
+
+  it("updateIdentity calls update", async () => {
+    setupTables({
+      identities,
+      identity_habits: [],
+      routines: [],
+      check_ins: [],
+    });
+
+    const { result } = renderHook(() => useIdentities());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateIdentity("i1", "I am a daily reader");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("identities");
+  });
+
+  it("deleteIdentity soft-deletes with archived_at", async () => {
+    setupTables({
+      identities,
+      identity_habits: [],
+      routines: [],
+      check_ins: [],
+    });
+
+    const { result } = renderHook(() => useIdentities());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.deleteIdentity("i1");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("identities");
+  });
+
+  it("updateLinks adds and removes links", async () => {
+    const links = [
+      { id: "ih1", identity_id: "i1", routine_id: "r1", user_id: "user-1" },
+    ];
+
+    setupTables({
+      identities,
+      identity_habits: links,
+      routines: [],
+      check_ins: [],
+    });
+
+    const { result } = renderHook(() => useIdentities());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      // Remove r1, add r2
+      await result.current.updateLinks("i1", ["r2"]);
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("identity_habits");
+  });
+});
+
+// ─── usePartners mutations ───────────────────────────────
+
+describe("usePartners mutations", () => {
+  it("generateInviteLink creates partnership and returns URL", async () => {
+    setupTables({ partnerships: [], nudges: [], profiles: [] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let url: string = "";
+    await act(async () => {
+      url = await result.current.generateInviteLink();
+    });
+
+    expect(url).toContain("/invite/");
+    expect(mockFrom).toHaveBeenCalledWith("partnerships");
+  });
+
+  it("acceptInvite updates partnership status", async () => {
+    const partnerships = [
+      { id: "p1", requester_id: "user-2", partner_id: "user-1", invite_token: "tok", invite_email: null, status: "pending", created_at: "2026-03-01", updated_at: "2026-03-01" },
+    ];
+
+    setupTables({ partnerships, nudges: [], profiles: [{ id: "user-2", display_name: "Someone" }] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.acceptInvite("p1");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("partnerships");
+  });
+
+  it("declineInvite updates partnership status", async () => {
+    setupTables({ partnerships: [], nudges: [], profiles: [] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.declineInvite("p1");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("partnerships");
+  });
+
+  it("removePartner deletes partnership", async () => {
+    setupTables({ partnerships: [], nudges: [], profiles: [] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.removePartner("p1");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("partnerships");
+  });
+
+  it("sendNudge inserts a nudge", async () => {
+    setupTables({ partnerships: [], nudges: [], profiles: [] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.sendNudge("p1", "user-2", "Keep going! 💪");
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("nudges");
+  });
+
+  it("markNudgesRead updates unread nudges", async () => {
+    const nudges = [
+      { id: "n1", partnership_id: "p1", sender_id: "user-2", receiver_id: "user-1", message: "Go!", read: false, created_at: "2026-03-11" },
+    ];
+
+    setupTables({ partnerships: [], nudges, profiles: [] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.unreadNudgeCount).toBe(1);
+
+    await act(async () => {
+      await result.current.markNudgesRead();
+    });
+
+    // Optimistic update should set read = true
+    expect(result.current.unreadNudgeCount).toBe(0);
+  });
+
+  it("generateInviteLink throws when not authenticated", async () => {
+    setupTables({ partnerships: [], nudges: [], profiles: [] });
+
+    const { result } = renderHook(() => usePartners());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mockNoAuth();
+
+    await expect(
+      act(async () => {
+        await result.current.generateInviteLink();
+      })
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/src/hooks/__tests__/hooks.mutations.test.ts
+++ b/src/hooks/__tests__/hooks.mutations.test.ts
@@ -26,10 +26,25 @@ function createChainableQuery(data: unknown = [], error: unknown = null) {
   const builder: Record<string, unknown> = {};
 
   const chainMethods = [
-    "select", "eq", "neq", "in", "is", "or", "not",
-    "order", "limit", "filter", "match",
-    "gt", "gte", "lt", "lte",
-    "insert", "update", "delete", "upsert",
+    "select",
+    "eq",
+    "neq",
+    "in",
+    "is",
+    "or",
+    "not",
+    "order",
+    "limit",
+    "filter",
+    "match",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "insert",
+    "update",
+    "delete",
+    "upsert",
   ];
 
   chainMethods.forEach((m) => {
@@ -38,8 +53,10 @@ function createChainableQuery(data: unknown = [], error: unknown = null) {
 
   builder.single = vi.fn().mockResolvedValue(resolved);
 
-  builder.then = (resolve: (v: unknown) => void, reject?: (r: unknown) => void) =>
-    Promise.resolve(resolved).then(resolve, reject);
+  builder.then = (
+    resolve: (v: unknown) => void,
+    reject?: (r: unknown) => void
+  ) => Promise.resolve(resolved).then(resolve, reject);
 
   return builder;
 }
@@ -81,7 +98,17 @@ beforeEach(() => {
 
 describe("useRoutines mutations", () => {
   const routines = [
-    { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    {
+      id: "r1",
+      user_id: "user-1",
+      name: "Coffee",
+      tag: "neutral",
+      time_of_day: "morning",
+      sort_order: 0,
+      archived_at: null,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    },
   ];
 
   it("addRoutine calls insert and refreshes", async () => {
@@ -91,7 +118,11 @@ describe("useRoutines mutations", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.addRoutine({ name: "Journal", tag: "positive", time_of_day: "morning" });
+      await result.current.addRoutine({
+        name: "Journal",
+        tag: "positive",
+        time_of_day: "morning",
+      });
     });
 
     // from("routines").insert(...) should have been called
@@ -146,7 +177,15 @@ describe("useRoutines mutations", () => {
 
 describe("useCheckIns mutations", () => {
   const checkIns = [
-    { id: "c1", user_id: "user-1", routine_id: "r1", date: "2026-03-11", completed: false, created_at: "2026-03-11", updated_at: "2026-03-11" },
+    {
+      id: "c1",
+      user_id: "user-1",
+      routine_id: "r1",
+      date: "2026-03-11",
+      completed: false,
+      created_at: "2026-03-11",
+      updated_at: "2026-03-11",
+    },
   ];
 
   it("toggleCheckIn flips existing check-in to completed", async () => {
@@ -196,11 +235,38 @@ describe("useCheckIns mutations", () => {
 
 describe("useStacks mutations", () => {
   const routines = [
-    { id: "r1", user_id: "user-1", name: "Coffee", tag: "neutral", time_of_day: "morning", sort_order: 0, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
-    { id: "r2", user_id: "user-1", name: "Journal", tag: "positive", time_of_day: "morning", sort_order: 1, archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    {
+      id: "r1",
+      user_id: "user-1",
+      name: "Coffee",
+      tag: "neutral",
+      time_of_day: "morning",
+      sort_order: 0,
+      archived_at: null,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    },
+    {
+      id: "r2",
+      user_id: "user-1",
+      name: "Journal",
+      tag: "positive",
+      time_of_day: "morning",
+      sort_order: 1,
+      archived_at: null,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    },
   ];
   const stacks = [
-    { id: "s1", user_id: "user-1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0, created_at: "2026-01-01" },
+    {
+      id: "s1",
+      user_id: "user-1",
+      anchor_routine_id: "r1",
+      stacked_routine_id: "r2",
+      position: 0,
+      created_at: "2026-01-01",
+    },
   ];
 
   it("addStack calls insert and refreshes", async () => {
@@ -255,7 +321,14 @@ describe("useStacks mutations", () => {
 
 describe("useIdentities mutations", () => {
   const identities = [
-    { id: "i1", user_id: "user-1", statement: "I am a reader", archived_at: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+    {
+      id: "i1",
+      user_id: "user-1",
+      statement: "I am a reader",
+      archived_at: null,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    },
   ];
 
   it("addIdentity calls insert for identity and links", async () => {
@@ -263,7 +336,9 @@ describe("useIdentities mutations", () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === "identities") {
         const builder = createChainableQuery(identities);
-        builder.single = vi.fn().mockResolvedValue({ data: { id: "i-new" }, error: null });
+        builder.single = vi
+          .fn()
+          .mockResolvedValue({ data: { id: "i-new" }, error: null });
         return builder;
       }
       return createChainableQuery([]);
@@ -365,10 +440,23 @@ describe("usePartners mutations", () => {
 
   it("acceptInvite updates partnership status", async () => {
     const partnerships = [
-      { id: "p1", requester_id: "user-2", partner_id: "user-1", invite_token: "tok", invite_email: null, status: "pending", created_at: "2026-03-01", updated_at: "2026-03-01" },
+      {
+        id: "p1",
+        requester_id: "user-2",
+        partner_id: "user-1",
+        invite_token: "tok",
+        invite_email: null,
+        status: "pending",
+        created_at: "2026-03-01",
+        updated_at: "2026-03-01",
+      },
     ];
 
-    setupTables({ partnerships, nudges: [], profiles: [{ id: "user-2", display_name: "Someone" }] });
+    setupTables({
+      partnerships,
+      nudges: [],
+      profiles: [{ id: "user-2", display_name: "Someone" }],
+    });
 
     const { result } = renderHook(() => usePartners());
 
@@ -425,7 +513,15 @@ describe("usePartners mutations", () => {
 
   it("markNudgesRead updates unread nudges", async () => {
     const nudges = [
-      { id: "n1", partnership_id: "p1", sender_id: "user-2", receiver_id: "user-1", message: "Go!", read: false, created_at: "2026-03-11" },
+      {
+        id: "n1",
+        partnership_id: "p1",
+        sender_id: "user-2",
+        receiver_id: "user-1",
+        message: "Go!",
+        read: false,
+        created_at: "2026-03-11",
+      },
     ];
 
     setupTables({ partnerships: [], nudges, profiles: [] });

--- a/src/hooks/__tests__/useIdentities.test.ts
+++ b/src/hooks/__tests__/useIdentities.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getLocalDateString,
+  getLast7Days,
+  buildIdentitiesWithDetails,
+} from "../useIdentities";
+import type {
+  Identity,
+  IdentityHabit,
+  Routine,
+  CheckIn,
+} from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "u1",
+    name: "Test Routine",
+    tag: "positive",
+    time_of_day: "morning",
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeIdentity(overrides: Partial<Identity> = {}): Identity {
+  return {
+    id: "i1",
+    user_id: "u1",
+    statement: "I am a reader",
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeIdentityHabit(overrides: Partial<IdentityHabit> = {}): IdentityHabit {
+  return {
+    id: "ih1",
+    identity_id: "i1",
+    routine_id: "r1",
+    user_id: "u1",
+    ...overrides,
+  };
+}
+
+function makeCheckIn(overrides: Partial<CheckIn> = {}): CheckIn {
+  return {
+    id: "ci1",
+    user_id: "u1",
+    routine_id: "r1",
+    date: "2026-03-11",
+    completed: true,
+    created_at: "2026-03-11T08:00:00Z",
+    updated_at: "2026-03-11T08:00:00Z",
+    ...overrides,
+  };
+}
+
+// ─── getLocalDateString ──────────────────────────────────
+
+describe("getLocalDateString", () => {
+  it("formats a date as YYYY-MM-DD", () => {
+    const date = new Date(2026, 2, 11); // March 11, 2026 (month is 0-indexed)
+    expect(getLocalDateString(date)).toBe("2026-03-11");
+  });
+
+  it("pads single-digit month and day", () => {
+    const date = new Date(2026, 0, 5); // Jan 5
+    expect(getLocalDateString(date)).toBe("2026-01-05");
+  });
+});
+
+// ─── getLast7Days ────────────────────────────────────────
+
+describe("getLast7Days", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 11)); // March 11, 2026
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 7 dates", () => {
+    const days = getLast7Days();
+    expect(days).toHaveLength(7);
+  });
+
+  it("ends with today", () => {
+    const days = getLast7Days();
+    expect(days[6]).toBe("2026-03-11");
+  });
+
+  it("starts 6 days ago", () => {
+    const days = getLast7Days();
+    expect(days[0]).toBe("2026-03-05");
+  });
+
+  it("returns dates in ascending order", () => {
+    const days = getLast7Days();
+    for (let i = 1; i < days.length; i++) {
+      expect(days[i] > days[i - 1]).toBe(true);
+    }
+  });
+});
+
+// ─── buildIdentitiesWithDetails ─────────────────────────
+
+describe("buildIdentitiesWithDetails", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 11)); // March 11, 2026
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns enriched identities with linked routines", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
+    const routines = [makeRoutine({ id: "r1", name: "Read" })];
+    const checkIns: CheckIn[] = [];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].linked_routines).toHaveLength(1);
+    expect(result[0].linked_routines[0].name).toBe("Read");
+  });
+
+  it("computes total_votes from completed check-ins", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
+    const routines = [makeRoutine({ id: "r1" })];
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-10", completed: true }),
+      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c3", routine_id: "r1", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].total_votes).toBe(3);
+  });
+
+  it("does not count incomplete check-ins as votes", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
+    const routines = [makeRoutine({ id: "r1" })];
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-10", completed: false }),
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].total_votes).toBe(1);
+  });
+
+  it("computes votes_today for today only", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
+    const routines = [makeRoutine({ id: "r1" })];
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-10", completed: true }),
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].votes_today).toBe(1);
+  });
+
+  it("computes votes_this_week from week start", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
+    const routines = [makeRoutine({ id: "r1" })];
+    // March 11 2026 is a Wednesday. Week starts March 5 (Thursday in last7Days logic).
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-09", completed: true }),
+      makeCheckIn({ id: "c3", routine_id: "r1", date: "2026-03-05", completed: true }),
+      makeCheckIn({ id: "c4", routine_id: "r1", date: "2026-03-01", completed: true }), // outside week
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    // votes_this_week counts check-ins from the first of the last 7 days onward
+    expect(result[0].votes_this_week).toBe(3);
+  });
+
+  it("builds vote_history for last 7 days", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
+    const routines = [makeRoutine({ id: "r1" })];
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].vote_history).toHaveLength(7);
+
+    // Today should have 1 vote
+    const todayEntry = result[0].vote_history.find((d) => d.date === "2026-03-11");
+    expect(todayEntry?.count).toBe(1);
+
+    // March 9 should have 1 vote
+    const mar9Entry = result[0].vote_history.find((d) => d.date === "2026-03-09");
+    expect(mar9Entry?.count).toBe(1);
+
+    // Other days should be 0
+    const mar10Entry = result[0].vote_history.find((d) => d.date === "2026-03-10");
+    expect(mar10Entry?.count).toBe(0);
+  });
+
+  it("handles identity with no linked routines", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links: IdentityHabit[] = [];
+    const routines = [makeRoutine({ id: "r1" })];
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].linked_routines).toHaveLength(0);
+    expect(result[0].total_votes).toBe(0);
+    expect(result[0].votes_today).toBe(0);
+  });
+
+  it("handles multiple identities independently", () => {
+    const identities = [
+      makeIdentity({ id: "i1", statement: "I am a reader" }),
+      makeIdentity({ id: "i2", statement: "I am fit" }),
+    ];
+    const links = [
+      makeIdentityHabit({ id: "ih1", identity_id: "i1", routine_id: "r1" }),
+      makeIdentityHabit({ id: "ih2", identity_id: "i2", routine_id: "r2" }),
+    ];
+    const routines = [
+      makeRoutine({ id: "r1", name: "Read" }),
+      makeRoutine({ id: "r2", name: "Exercise" }),
+    ];
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+    ];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].total_votes).toBe(1); // reader has a vote
+    expect(result[1].total_votes).toBe(0); // fit has no vote
+  });
+
+  it("skips archived/missing routines in linked_routines", () => {
+    const identities = [makeIdentity({ id: "i1" })];
+    const links = [
+      makeIdentityHabit({ id: "ih1", identity_id: "i1", routine_id: "r1" }),
+      makeIdentityHabit({ id: "ih2", identity_id: "i1", routine_id: "r_missing" }),
+    ];
+    const routines = [makeRoutine({ id: "r1", name: "Read" })];
+    const checkIns: CheckIn[] = [];
+
+    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    expect(result[0].linked_routines).toHaveLength(1);
+    expect(result[0].linked_routines[0].name).toBe("Read");
+  });
+});

--- a/src/hooks/__tests__/useIdentities.test.ts
+++ b/src/hooks/__tests__/useIdentities.test.ts
@@ -40,7 +40,9 @@ function makeIdentity(overrides: Partial<Identity> = {}): Identity {
   };
 }
 
-function makeIdentityHabit(overrides: Partial<IdentityHabit> = {}): IdentityHabit {
+function makeIdentityHabit(
+  overrides: Partial<IdentityHabit> = {}
+): IdentityHabit {
   return {
     id: "ih1",
     identity_id: "i1",
@@ -130,7 +132,12 @@ describe("buildIdentitiesWithDetails", () => {
     const routines = [makeRoutine({ id: "r1", name: "Read" })];
     const checkIns: CheckIn[] = [];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].linked_routines).toHaveLength(1);
@@ -142,12 +149,32 @@ describe("buildIdentitiesWithDetails", () => {
     const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
     const routines = [makeRoutine({ id: "r1" })];
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-10", completed: true }),
-      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-11", completed: true }),
-      makeCheckIn({ id: "c3", routine_id: "r1", date: "2026-03-09", completed: true }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-10",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c2",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c3",
+        routine_id: "r1",
+        date: "2026-03-09",
+        completed: true,
+      }),
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].total_votes).toBe(3);
   });
 
@@ -156,11 +183,26 @@ describe("buildIdentitiesWithDetails", () => {
     const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
     const routines = [makeRoutine({ id: "r1" })];
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
-      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-10", completed: false }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c2",
+        routine_id: "r1",
+        date: "2026-03-10",
+        completed: false,
+      }),
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].total_votes).toBe(1);
   });
 
@@ -169,11 +211,26 @@ describe("buildIdentitiesWithDetails", () => {
     const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
     const routines = [makeRoutine({ id: "r1" })];
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
-      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-10", completed: true }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c2",
+        routine_id: "r1",
+        date: "2026-03-10",
+        completed: true,
+      }),
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].votes_today).toBe(1);
   });
 
@@ -183,13 +240,38 @@ describe("buildIdentitiesWithDetails", () => {
     const routines = [makeRoutine({ id: "r1" })];
     // March 11 2026 is a Wednesday. Week starts March 5 (Thursday in last7Days logic).
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
-      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-09", completed: true }),
-      makeCheckIn({ id: "c3", routine_id: "r1", date: "2026-03-05", completed: true }),
-      makeCheckIn({ id: "c4", routine_id: "r1", date: "2026-03-01", completed: true }), // outside week
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c2",
+        routine_id: "r1",
+        date: "2026-03-09",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c3",
+        routine_id: "r1",
+        date: "2026-03-05",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c4",
+        routine_id: "r1",
+        date: "2026-03-01",
+        completed: true,
+      }), // outside week
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     // votes_this_week counts check-ins from the first of the last 7 days onward
     expect(result[0].votes_this_week).toBe(3);
   });
@@ -199,23 +281,44 @@ describe("buildIdentitiesWithDetails", () => {
     const links = [makeIdentityHabit({ identity_id: "i1", routine_id: "r1" })];
     const routines = [makeRoutine({ id: "r1" })];
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
-      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-09", completed: true }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c2",
+        routine_id: "r1",
+        date: "2026-03-09",
+        completed: true,
+      }),
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].vote_history).toHaveLength(7);
 
     // Today should have 1 vote
-    const todayEntry = result[0].vote_history.find((d) => d.date === "2026-03-11");
+    const todayEntry = result[0].vote_history.find(
+      (d) => d.date === "2026-03-11"
+    );
     expect(todayEntry?.count).toBe(1);
 
     // March 9 should have 1 vote
-    const mar9Entry = result[0].vote_history.find((d) => d.date === "2026-03-09");
+    const mar9Entry = result[0].vote_history.find(
+      (d) => d.date === "2026-03-09"
+    );
     expect(mar9Entry?.count).toBe(1);
 
     // Other days should be 0
-    const mar10Entry = result[0].vote_history.find((d) => d.date === "2026-03-10");
+    const mar10Entry = result[0].vote_history.find(
+      (d) => d.date === "2026-03-10"
+    );
     expect(mar10Entry?.count).toBe(0);
   });
 
@@ -224,10 +327,20 @@ describe("buildIdentitiesWithDetails", () => {
     const links: IdentityHabit[] = [];
     const routines = [makeRoutine({ id: "r1" })];
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].linked_routines).toHaveLength(0);
     expect(result[0].total_votes).toBe(0);
     expect(result[0].votes_today).toBe(0);
@@ -247,10 +360,20 @@ describe("buildIdentitiesWithDetails", () => {
       makeRoutine({ id: "r2", name: "Exercise" }),
     ];
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
     ];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].total_votes).toBe(1); // reader has a vote
     expect(result[1].total_votes).toBe(0); // fit has no vote
   });
@@ -259,12 +382,21 @@ describe("buildIdentitiesWithDetails", () => {
     const identities = [makeIdentity({ id: "i1" })];
     const links = [
       makeIdentityHabit({ id: "ih1", identity_id: "i1", routine_id: "r1" }),
-      makeIdentityHabit({ id: "ih2", identity_id: "i1", routine_id: "r_missing" }),
+      makeIdentityHabit({
+        id: "ih2",
+        identity_id: "i1",
+        routine_id: "r_missing",
+      }),
     ];
     const routines = [makeRoutine({ id: "r1", name: "Read" })];
     const checkIns: CheckIn[] = [];
 
-    const result = buildIdentitiesWithDetails(identities, links, routines, checkIns);
+    const result = buildIdentitiesWithDetails(
+      identities,
+      links,
+      routines,
+      checkIns
+    );
     expect(result[0].linked_routines).toHaveLength(1);
     expect(result[0].linked_routines[0].name).toBe("Read");
   });

--- a/src/hooks/__tests__/usePartners.test.ts
+++ b/src/hooks/__tests__/usePartners.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { computeStreaks, getWeekStart, getLocalDateString } from "../usePartners";
+import {
+  computeStreaks,
+  getWeekStart,
+  getLocalDateString,
+} from "../usePartners";
 import type { CheckIn, Routine } from "@/types/database";
 
 // ─── Factories ───────────────────────────────────────────
@@ -196,9 +200,24 @@ describe("computeStreaks", () => {
     ];
     // 3 days this week, 1 active routine = 3 max
     const checkIns = [
-      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
-      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-10", completed: true }),
-      makeCheckIn({ id: "c3", routine_id: "r1", date: "2026-03-09", completed: true }),
+      makeCheckIn({
+        id: "c1",
+        routine_id: "r1",
+        date: "2026-03-11",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c2",
+        routine_id: "r1",
+        date: "2026-03-10",
+        completed: true,
+      }),
+      makeCheckIn({
+        id: "c3",
+        routine_id: "r1",
+        date: "2026-03-09",
+        completed: true,
+      }),
     ];
 
     const result = computeStreaks(checkIns, mixedRoutines);

--- a/src/hooks/__tests__/usePartners.test.ts
+++ b/src/hooks/__tests__/usePartners.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { computeStreaks, getWeekStart, getLocalDateString } from "../usePartners";
+import type { CheckIn, Routine } from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "u1",
+    name: "Test",
+    tag: "positive",
+    time_of_day: null,
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeCheckIn(overrides: Partial<CheckIn> = {}): CheckIn {
+  return {
+    id: "ci1",
+    user_id: "u1",
+    routine_id: "r1",
+    date: "2026-03-11",
+    completed: true,
+    created_at: "2026-03-11T08:00:00Z",
+    updated_at: "2026-03-11T08:00:00Z",
+    ...overrides,
+  };
+}
+
+// ─── getLocalDateString ──────────────────────────────────
+
+describe("getLocalDateString (partners)", () => {
+  it("formats date as YYYY-MM-DD", () => {
+    const date = new Date(2026, 2, 11);
+    expect(getLocalDateString(date)).toBe("2026-03-11");
+  });
+
+  it("pads single digits", () => {
+    const date = new Date(2026, 0, 3);
+    expect(getLocalDateString(date)).toBe("2026-01-03");
+  });
+});
+
+// ─── getWeekStart ────────────────────────────────────────
+
+describe("getWeekStart", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns Monday for a Wednesday", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 11)); // Wednesday March 11
+    expect(getWeekStart()).toBe("2026-03-09"); // Monday March 9
+  });
+
+  it("returns same day for a Monday", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 9)); // Monday March 9
+    expect(getWeekStart()).toBe("2026-03-09");
+  });
+
+  it("returns previous Monday for a Sunday", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15)); // Sunday March 15
+    expect(getWeekStart()).toBe("2026-03-09"); // Monday March 9
+  });
+});
+
+// ─── computeStreaks ──────────────────────────────────────
+
+describe("computeStreaks", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 11)); // March 11, 2026 (Wednesday)
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const routines = [makeRoutine({ id: "r1" })];
+
+  it("computes current streak counting backwards from today", () => {
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", date: "2026-03-10", completed: true }),
+      makeCheckIn({ id: "c3", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.currentStreak).toBe(3);
+  });
+
+  it("gives grace period when today has no check-ins", () => {
+    // Yesterday and day before have check-ins, today does not
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-10", completed: true }),
+      makeCheckIn({ id: "c2", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.currentStreak).toBe(2);
+  });
+
+  it("returns 0 when no completed check-ins", () => {
+    const result = computeStreaks([], routines);
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(0);
+  });
+
+  it("breaks streak on gap day", () => {
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-11", completed: true }),
+      // gap on March 10
+      makeCheckIn({ id: "c2", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.currentStreak).toBe(1); // only today
+  });
+
+  it("computes longest streak across all history", () => {
+    const checkIns = [
+      // Old 4-day streak
+      makeCheckIn({ id: "c1", date: "2026-03-01", completed: true }),
+      makeCheckIn({ id: "c2", date: "2026-03-02", completed: true }),
+      makeCheckIn({ id: "c3", date: "2026-03-03", completed: true }),
+      makeCheckIn({ id: "c4", date: "2026-03-04", completed: true }),
+      // gap
+      // current 2-day streak
+      makeCheckIn({ id: "c5", date: "2026-03-10", completed: true }),
+      makeCheckIn({ id: "c6", date: "2026-03-11", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.longestStreak).toBe(4);
+    expect(result.currentStreak).toBe(2);
+  });
+
+  it("longest equals current when current is the longest", () => {
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-09", completed: true }),
+      makeCheckIn({ id: "c2", date: "2026-03-10", completed: true }),
+      makeCheckIn({ id: "c3", date: "2026-03-11", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it("ignores incomplete check-ins for streaks", () => {
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", date: "2026-03-10", completed: false }), // not completed
+      makeCheckIn({ id: "c3", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.currentStreak).toBe(1); // only today, gap yesterday
+  });
+
+  it("computes completion rate this week", () => {
+    // Week starts Monday March 9, today is Wednesday March 11 = 3 days
+    // 1 routine × 3 days = 3 max possible
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-09", completed: true }),
+      makeCheckIn({ id: "c2", date: "2026-03-11", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    // 2 completed out of 3 possible = 67%
+    expect(result.completionRateThisWeek).toBe(67);
+  });
+
+  it("returns 0% completion with zero routines", () => {
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-11", completed: true }),
+    ];
+    const emptyRoutines: Routine[] = [];
+
+    const result = computeStreaks(checkIns, emptyRoutines);
+    expect(result.completionRateThisWeek).toBe(0);
+  });
+
+  it("excludes archived routines from completion rate", () => {
+    const mixedRoutines = [
+      makeRoutine({ id: "r1", archived_at: null }),
+      makeRoutine({ id: "r2", archived_at: "2026-03-01T00:00:00Z" }), // archived
+    ];
+    // 3 days this week, 1 active routine = 3 max
+    const checkIns = [
+      makeCheckIn({ id: "c1", routine_id: "r1", date: "2026-03-11", completed: true }),
+      makeCheckIn({ id: "c2", routine_id: "r1", date: "2026-03-10", completed: true }),
+      makeCheckIn({ id: "c3", routine_id: "r1", date: "2026-03-09", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, mixedRoutines);
+    expect(result.completionRateThisWeek).toBe(100);
+  });
+
+  it("handles single completed day", () => {
+    const checkIns = [
+      makeCheckIn({ id: "c1", date: "2026-03-11", completed: true }),
+    ];
+
+    const result = computeStreaks(checkIns, routines);
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+  });
+});

--- a/src/hooks/__tests__/useStacks.test.ts
+++ b/src/hooks/__tests__/useStacks.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildStacksWithRoutines,
+  buildChains,
+} from "../useStacks";
+import type { HabitStack, Routine } from "@/types/database";
+
+// ─── Factories ───────────────────────────────────────────
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    user_id: "u1",
+    name: "Test Routine",
+    tag: "positive",
+    time_of_day: "morning",
+    sort_order: 0,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeStack(overrides: Partial<HabitStack> = {}): HabitStack {
+  return {
+    id: "s1",
+    user_id: "u1",
+    anchor_routine_id: "r1",
+    stacked_routine_id: "r2",
+    position: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ─── buildStacksWithRoutines ─────────────────────────────
+
+describe("buildStacksWithRoutines", () => {
+  it("enriches raw stacks with routine data", () => {
+    const routines = [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Journal" }),
+    ];
+    const stacks = [makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2" })];
+
+    const result = buildStacksWithRoutines(stacks, routines);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].anchor_routine.name).toBe("Coffee");
+    expect(result[0].stacked_routine.name).toBe("Journal");
+  });
+
+  it("skips stacks where anchor routine is missing", () => {
+    const routines = [makeRoutine({ id: "r2", name: "Journal" })];
+    const stacks = [makeStack({ anchor_routine_id: "r1", stacked_routine_id: "r2" })];
+
+    const result = buildStacksWithRoutines(stacks, routines);
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips stacks where stacked routine is missing", () => {
+    const routines = [makeRoutine({ id: "r1", name: "Coffee" })];
+    const stacks = [makeStack({ anchor_routine_id: "r1", stacked_routine_id: "r2" })];
+
+    const result = buildStacksWithRoutines(stacks, routines);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when stacks are empty", () => {
+    const routines = [makeRoutine({ id: "r1" })];
+    const result = buildStacksWithRoutines([], routines);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when routines are empty", () => {
+    const stacks = [makeStack()];
+    const result = buildStacksWithRoutines(stacks, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles multiple stacks correctly", () => {
+    const routines = [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Journal" }),
+      makeRoutine({ id: "r3", name: "Stretch" }),
+    ];
+    const stacks = [
+      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+      makeStack({ id: "s2", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1 }),
+    ];
+
+    const result = buildStacksWithRoutines(stacks, routines);
+    expect(result).toHaveLength(2);
+    expect(result[0].stacked_routine.name).toBe("Journal");
+    expect(result[1].stacked_routine.name).toBe("Stretch");
+  });
+});
+
+// ─── buildChains ─────────────────────────────────────────
+
+describe("buildChains", () => {
+  it("groups stacks by anchor into a single chain", () => {
+    const routines = [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Journal" }),
+      makeRoutine({ id: "r3", name: "Stretch" }),
+    ];
+    const stacks = [
+      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+      makeStack({ id: "s2", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1 }),
+    ];
+    const enriched = buildStacksWithRoutines(stacks, routines);
+    const chains = buildChains(enriched);
+
+    expect(chains).toHaveLength(1);
+    expect(chains[0].anchor.name).toBe("Coffee");
+    expect(chains[0].steps).toHaveLength(2);
+    expect(chains[0].steps[0].routine.name).toBe("Journal");
+    expect(chains[0].steps[1].routine.name).toBe("Stretch");
+  });
+
+  it("sorts steps within a chain by position", () => {
+    const routines = [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Journal" }),
+      makeRoutine({ id: "r3", name: "Stretch" }),
+    ];
+    // Insert in reverse position order
+    const stacks = [
+      makeStack({ id: "s2", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1 }),
+      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+    ];
+    const enriched = buildStacksWithRoutines(stacks, routines);
+    const chains = buildChains(enriched);
+
+    expect(chains[0].steps[0].routine.name).toBe("Journal");
+    expect(chains[0].steps[1].routine.name).toBe("Stretch");
+  });
+
+  it("creates separate chains for different anchors", () => {
+    const routines = [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Journal" }),
+      makeRoutine({ id: "r3", name: "Lunch" }),
+      makeRoutine({ id: "r4", name: "Walk" }),
+    ];
+    const stacks = [
+      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+      makeStack({ id: "s2", anchor_routine_id: "r3", stacked_routine_id: "r4", position: 0 }),
+    ];
+    const enriched = buildStacksWithRoutines(stacks, routines);
+    const chains = buildChains(enriched);
+
+    expect(chains).toHaveLength(2);
+  });
+
+  it("handles single-step chain", () => {
+    const routines = [
+      makeRoutine({ id: "r1", name: "Coffee" }),
+      makeRoutine({ id: "r2", name: "Journal" }),
+    ];
+    const stacks = [
+      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+    ];
+    const enriched = buildStacksWithRoutines(stacks, routines);
+    const chains = buildChains(enriched);
+
+    expect(chains).toHaveLength(1);
+    expect(chains[0].steps).toHaveLength(1);
+  });
+
+  it("returns empty array for empty input", () => {
+    const chains = buildChains([]);
+    expect(chains).toHaveLength(0);
+  });
+});

--- a/src/hooks/__tests__/useStacks.test.ts
+++ b/src/hooks/__tests__/useStacks.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  buildStacksWithRoutines,
-  buildChains,
-} from "../useStacks";
+import { buildStacksWithRoutines, buildChains } from "../useStacks";
 import type { HabitStack, Routine } from "@/types/database";
 
 // ─── Factories ───────────────────────────────────────────
@@ -42,7 +39,13 @@ describe("buildStacksWithRoutines", () => {
       makeRoutine({ id: "r1", name: "Coffee" }),
       makeRoutine({ id: "r2", name: "Journal" }),
     ];
-    const stacks = [makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2" })];
+    const stacks = [
+      makeStack({
+        id: "s1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+      }),
+    ];
 
     const result = buildStacksWithRoutines(stacks, routines);
 
@@ -53,7 +56,9 @@ describe("buildStacksWithRoutines", () => {
 
   it("skips stacks where anchor routine is missing", () => {
     const routines = [makeRoutine({ id: "r2", name: "Journal" })];
-    const stacks = [makeStack({ anchor_routine_id: "r1", stacked_routine_id: "r2" })];
+    const stacks = [
+      makeStack({ anchor_routine_id: "r1", stacked_routine_id: "r2" }),
+    ];
 
     const result = buildStacksWithRoutines(stacks, routines);
     expect(result).toHaveLength(0);
@@ -61,7 +66,9 @@ describe("buildStacksWithRoutines", () => {
 
   it("skips stacks where stacked routine is missing", () => {
     const routines = [makeRoutine({ id: "r1", name: "Coffee" })];
-    const stacks = [makeStack({ anchor_routine_id: "r1", stacked_routine_id: "r2" })];
+    const stacks = [
+      makeStack({ anchor_routine_id: "r1", stacked_routine_id: "r2" }),
+    ];
 
     const result = buildStacksWithRoutines(stacks, routines);
     expect(result).toHaveLength(0);
@@ -86,8 +93,18 @@ describe("buildStacksWithRoutines", () => {
       makeRoutine({ id: "r3", name: "Stretch" }),
     ];
     const stacks = [
-      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
-      makeStack({ id: "s2", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1 }),
+      makeStack({
+        id: "s1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+      }),
+      makeStack({
+        id: "s2",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r3",
+        position: 1,
+      }),
     ];
 
     const result = buildStacksWithRoutines(stacks, routines);
@@ -107,8 +124,18 @@ describe("buildChains", () => {
       makeRoutine({ id: "r3", name: "Stretch" }),
     ];
     const stacks = [
-      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
-      makeStack({ id: "s2", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1 }),
+      makeStack({
+        id: "s1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+      }),
+      makeStack({
+        id: "s2",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r3",
+        position: 1,
+      }),
     ];
     const enriched = buildStacksWithRoutines(stacks, routines);
     const chains = buildChains(enriched);
@@ -128,8 +155,18 @@ describe("buildChains", () => {
     ];
     // Insert in reverse position order
     const stacks = [
-      makeStack({ id: "s2", anchor_routine_id: "r1", stacked_routine_id: "r3", position: 1 }),
-      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+      makeStack({
+        id: "s2",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r3",
+        position: 1,
+      }),
+      makeStack({
+        id: "s1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+      }),
     ];
     const enriched = buildStacksWithRoutines(stacks, routines);
     const chains = buildChains(enriched);
@@ -146,8 +183,18 @@ describe("buildChains", () => {
       makeRoutine({ id: "r4", name: "Walk" }),
     ];
     const stacks = [
-      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
-      makeStack({ id: "s2", anchor_routine_id: "r3", stacked_routine_id: "r4", position: 0 }),
+      makeStack({
+        id: "s1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+      }),
+      makeStack({
+        id: "s2",
+        anchor_routine_id: "r3",
+        stacked_routine_id: "r4",
+        position: 0,
+      }),
     ];
     const enriched = buildStacksWithRoutines(stacks, routines);
     const chains = buildChains(enriched);
@@ -161,7 +208,12 @@ describe("buildChains", () => {
       makeRoutine({ id: "r2", name: "Journal" }),
     ];
     const stacks = [
-      makeStack({ id: "s1", anchor_routine_id: "r1", stacked_routine_id: "r2", position: 0 }),
+      makeStack({
+        id: "s1",
+        anchor_routine_id: "r1",
+        stacked_routine_id: "r2",
+        position: 0,
+      }),
     ];
     const enriched = buildStacksWithRoutines(stacks, routines);
     const chains = buildChains(enriched);

--- a/src/hooks/useIdentities.ts
+++ b/src/hooks/useIdentities.ts
@@ -23,7 +23,7 @@ interface UseIdentitiesReturn {
 }
 
 /** Get YYYY-MM-DD for today in local timezone */
-function getLocalDateString(date: Date): string {
+export function getLocalDateString(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
@@ -31,7 +31,7 @@ function getLocalDateString(date: Date): string {
 }
 
 /** Get an array of YYYY-MM-DD strings for the last 7 days (today inclusive) */
-function getLast7Days(): string[] {
+export function getLast7Days(): string[] {
   const days: string[] = [];
   const now = new Date();
   for (let i = 6; i >= 0; i--) {
@@ -46,7 +46,7 @@ function getLast7Days(): string[] {
  * Compute enriched identity data by joining identities, identity_habits,
  * routines, and check_ins in JavaScript.
  */
-function buildIdentitiesWithDetails(
+export function buildIdentitiesWithDetails(
   rawIdentities: Identity[],
   identityHabits: IdentityHabit[],
   routines: Routine[],

--- a/src/hooks/usePartners.ts
+++ b/src/hooks/usePartners.ts
@@ -2,12 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { createClient } from "@/lib/supabase/client";
-import type {
-  Profile,
-  Routine,
-  CheckIn,
-  HabitStack,
-} from "@/types/database";
+import type { Profile, Routine, CheckIn, HabitStack } from "@/types/database";
 import type {
   Partnership,
   PartnershipWithProfile,
@@ -47,7 +42,11 @@ export function getWeekStart(): string {
 export function computeStreaks(
   checkIns: CheckIn[],
   routines: Routine[]
-): { currentStreak: number; longestStreak: number; completionRateThisWeek: number } {
+): {
+  currentStreak: number;
+  longestStreak: number;
+  completionRateThisWeek: number;
+} {
   // Collect unique dates with at least one completed check-in
   const completedDates = new Set<string>();
   checkIns.forEach((ci) => {
@@ -197,9 +196,7 @@ export function usePartners(): UsePartnersReturn {
         supabase
           .from("partnerships")
           .select("*")
-          .or(
-            `requester_id.eq.${user.id},partner_id.eq.${user.id}`
-          )
+          .or(`requester_id.eq.${user.id},partner_id.eq.${user.id}`)
           .neq("status", "declined")
           .order("created_at", { ascending: false }),
         supabase
@@ -333,13 +330,11 @@ export function usePartners(): UsePartnersReturn {
 
     const token = generateToken();
 
-    const { error: insertError } = await supabase
-      .from("partnerships")
-      .insert({
-        requester_id: user.id,
-        invite_token: token,
-        status: "pending",
-      });
+    const { error: insertError } = await supabase.from("partnerships").insert({
+      requester_id: user.id,
+      invite_token: token,
+      status: "pending",
+    });
 
     if (insertError) throw insertError;
 
@@ -408,11 +403,7 @@ export function usePartners(): UsePartnersReturn {
   );
 
   const sendNudge = useCallback(
-    async (
-      partnershipId: string,
-      receiverId: string,
-      message: string
-    ) => {
+    async (partnershipId: string, receiverId: string, message: string) => {
       const supabase = createClient();
       const {
         data: { user },
@@ -498,10 +489,7 @@ export function usePartners(): UsePartnersReturn {
             .eq("user_id", partnerUserId)
             .is("archived_at", null)
             .order("sort_order", { ascending: true }),
-          supabase
-            .from("check_ins")
-            .select("*")
-            .eq("user_id", partnerUserId),
+          supabase.from("check_ins").select("*").eq("user_id", partnerUserId),
           supabase
             .from("habit_stacks")
             .select("*")

--- a/src/hooks/usePartners.ts
+++ b/src/hooks/usePartners.ts
@@ -1,0 +1,555 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type {
+  Profile,
+  Routine,
+  CheckIn,
+  HabitStack,
+} from "@/types/database";
+import type {
+  Partnership,
+  PartnershipWithProfile,
+  Nudge,
+  PartnerSnapshot,
+} from "@/types/partners";
+
+// ─── Helpers ────────────────────────────────────────────
+
+/** YYYY-MM-DD in local timezone */
+export function getLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Generate a crypto-random token for invite links */
+function generateToken(): string {
+  return crypto.randomUUID();
+}
+
+/** Get the start-of-week date string (Monday) for the current week */
+export function getWeekStart(): string {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = now.getDate() - day + (day === 0 ? -6 : 1); // Monday
+  const monday = new Date(now);
+  monday.setDate(diff);
+  return getLocalDateString(monday);
+}
+
+/**
+ * Compute streak data from check-ins and routines.
+ * A "streak day" = at least one completed check-in on that date.
+ */
+export function computeStreaks(
+  checkIns: CheckIn[],
+  routines: Routine[]
+): { currentStreak: number; longestStreak: number; completionRateThisWeek: number } {
+  // Collect unique dates with at least one completed check-in
+  const completedDates = new Set<string>();
+  checkIns.forEach((ci) => {
+    if (ci.completed) completedDates.add(ci.date);
+  });
+
+  const sortedDates = Array.from(completedDates).sort().reverse();
+
+  // Current streak: count consecutive days backwards from today
+  let currentStreak = 0;
+  const cursor = new Date();
+
+  for (let i = 0; i < 365; i++) {
+    const dateStr = getLocalDateString(cursor);
+    if (completedDates.has(dateStr)) {
+      currentStreak++;
+      cursor.setDate(cursor.getDate() - 1);
+    } else {
+      // If today has no check-ins yet, check if yesterday starts a streak
+      if (i === 0) {
+        cursor.setDate(cursor.getDate() - 1);
+        continue;
+      }
+      break;
+    }
+  }
+
+  // Longest streak: walk all sorted dates forward
+  let longestStreak = 0;
+  let runLength = 0;
+  let prevDate: Date | null = null;
+
+  // Sort ascending for forward walk
+  const ascending = Array.from(completedDates).sort();
+  ascending.forEach((dateStr) => {
+    const current = new Date(dateStr + "T00:00:00");
+    if (prevDate) {
+      const diffMs = current.getTime() - prevDate.getTime();
+      const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+      if (diffDays === 1) {
+        runLength++;
+      } else {
+        runLength = 1;
+      }
+    } else {
+      runLength = 1;
+    }
+    longestStreak = Math.max(longestStreak, runLength);
+    prevDate = current;
+  });
+
+  // Completion rate this week: completed / (routines × days so far this week)
+  const weekStart = getWeekStart();
+  const today = getLocalDateString(new Date());
+  const todayDate = new Date();
+  const weekStartDate = new Date(weekStart + "T00:00:00");
+  const daysThisWeek =
+    Math.floor(
+      (todayDate.getTime() - weekStartDate.getTime()) / (1000 * 60 * 60 * 24)
+    ) + 1;
+
+  const activeRoutineCount = routines.filter((r) => !r.archived_at).length;
+  const maxPossible = activeRoutineCount * daysThisWeek;
+
+  const completedThisWeek = checkIns.filter(
+    (ci) => ci.completed && ci.date >= weekStart && ci.date <= today
+  ).length;
+
+  const completionRateThisWeek =
+    maxPossible > 0 ? Math.round((completedThisWeek / maxPossible) * 100) : 0;
+
+  return { currentStreak, longestStreak, completionRateThisWeek };
+}
+
+// ─── Hook Return Type ───────────────────────────────────
+
+interface UsePartnersReturn {
+  /** Active partnerships */
+  partnerships: PartnershipWithProfile[];
+  /** Invites sent TO the current user (pending, awaiting accept/decline) */
+  pendingInvites: PartnershipWithProfile[];
+  /** Invites sent BY the current user that haven't been accepted yet */
+  sentInvites: Partnership[];
+  /** Unread nudge count */
+  unreadNudgeCount: number;
+  /** Recent nudges for the current user */
+  nudges: Nudge[];
+  loading: boolean;
+  error: string | null;
+
+  /** Create an invite link. Returns the full URL to share. */
+  generateInviteLink: () => Promise<string>;
+  /** Accept a pending invite */
+  acceptInvite: (partnershipId: string) => Promise<void>;
+  /** Decline a pending invite */
+  declineInvite: (partnershipId: string) => Promise<void>;
+  /** Remove an active partnership (hard delete) */
+  removePartner: (partnershipId: string) => Promise<void>;
+  /** Send a nudge to a partner */
+  sendNudge: (
+    partnershipId: string,
+    receiverId: string,
+    message: string
+  ) => Promise<void>;
+  /** Mark all unread nudges as read */
+  markNudgesRead: () => Promise<void>;
+  /** Fetch a read-only snapshot of a partner's data */
+  fetchPartnerSnapshot: (partnerUserId: string) => Promise<PartnerSnapshot>;
+  /** Re-fetch all partnership data */
+  refreshPartners: () => Promise<void>;
+}
+
+// ─── Hook ───────────────────────────────────────────────
+
+export function usePartners(): UsePartnersReturn {
+  const [rawPartnerships, setRawPartnerships] = useState<Partnership[]>([]);
+  const [partnerProfiles, setPartnerProfiles] = useState<
+    Map<string, Pick<Profile, "id" | "display_name">>
+  >(new Map());
+  const [nudges, setNudges] = useState<Nudge[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+
+  // ─── Fetch All ──────────────────────────────────────
+
+  const fetchAll = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setRawPartnerships([]);
+        setNudges([]);
+        return;
+      }
+
+      setUserId(user.id);
+
+      // Fetch partnerships and nudges in parallel
+      const [partnershipsRes, nudgesRes] = await Promise.all([
+        supabase
+          .from("partnerships")
+          .select("*")
+          .or(
+            `requester_id.eq.${user.id},partner_id.eq.${user.id}`
+          )
+          .neq("status", "declined")
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("nudges")
+          .select("*")
+          .eq("receiver_id", user.id)
+          .order("created_at", { ascending: false })
+          .limit(50),
+      ]);
+
+      if (partnershipsRes.error) throw partnershipsRes.error;
+      if (nudgesRes.error) throw nudgesRes.error;
+
+      const partnerships = (partnershipsRes.data ?? []) as Partnership[];
+      setRawPartnerships(partnerships);
+      setNudges((nudgesRes.data ?? []) as Nudge[]);
+
+      // Collect unique partner user IDs to fetch their profiles
+      const partnerUserIds = new Set<string>();
+      partnerships.forEach((p) => {
+        if (p.requester_id !== user.id && p.requester_id) {
+          partnerUserIds.add(p.requester_id);
+        }
+        if (p.partner_id && p.partner_id !== user.id) {
+          partnerUserIds.add(p.partner_id);
+        }
+      });
+
+      // Fetch partner profiles
+      if (partnerUserIds.size > 0) {
+        const { data: profiles, error: profilesError } = await supabase
+          .from("profiles")
+          .select("id, display_name")
+          .in("id", Array.from(partnerUserIds));
+
+        if (profilesError) throw profilesError;
+
+        const profileMap = new Map<
+          string,
+          Pick<Profile, "id" | "display_name">
+        >();
+        (profiles ?? []).forEach((p) => profileMap.set(p.id, p));
+        setPartnerProfiles(profileMap);
+      } else {
+        setPartnerProfiles(new Map());
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to fetch partners";
+      const isConnectionIssue =
+        message.includes("URL") ||
+        message.includes("API key") ||
+        message.includes("fetch");
+
+      if (isConnectionIssue) {
+        console.warn(
+          "usePartners: Supabase not configured, showing empty state"
+        );
+        setRawPartnerships([]);
+        setNudges([]);
+      } else {
+        setError(message);
+        console.error("usePartners fetch error:", err);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  // ─── Derived Data ─────────────────────────────────────
+
+  /** Active partnerships enriched with partner profiles */
+  const partnerships = useMemo<PartnershipWithProfile[]>(() => {
+    if (!userId) return [];
+
+    return rawPartnerships
+      .filter((p) => p.status === "active" && p.partner_id)
+      .map((p) => {
+        const otherUserId =
+          p.requester_id === userId ? p.partner_id! : p.requester_id;
+        const profile = partnerProfiles.get(otherUserId) ?? {
+          id: otherUserId,
+          display_name: null,
+        };
+        return { ...p, partner_profile: profile };
+      });
+  }, [rawPartnerships, partnerProfiles, userId]);
+
+  /** Pending invites sent TO the current user */
+  const pendingInvites = useMemo<PartnershipWithProfile[]>(() => {
+    if (!userId) return [];
+
+    return rawPartnerships
+      .filter((p) => p.status === "pending" && p.partner_id === userId)
+      .map((p) => {
+        const profile = partnerProfiles.get(p.requester_id) ?? {
+          id: p.requester_id,
+          display_name: null,
+        };
+        return { ...p, partner_profile: profile };
+      });
+  }, [rawPartnerships, partnerProfiles, userId]);
+
+  /** Invites sent BY the current user still waiting */
+  const sentInvites = useMemo<Partnership[]>(() => {
+    if (!userId) return [];
+    return rawPartnerships.filter(
+      (p) => p.status === "pending" && p.requester_id === userId
+    );
+  }, [rawPartnerships, userId]);
+
+  /** Unread nudge count */
+  const unreadNudgeCount = useMemo(
+    () => nudges.filter((n) => !n.read).length,
+    [nudges]
+  );
+
+  // ─── Actions ──────────────────────────────────────────
+
+  const generateInviteLink = useCallback(async (): Promise<string> => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) throw new Error("Not authenticated");
+
+    const token = generateToken();
+
+    const { error: insertError } = await supabase
+      .from("partnerships")
+      .insert({
+        requester_id: user.id,
+        invite_token: token,
+        status: "pending",
+      });
+
+    if (insertError) throw insertError;
+
+    await fetchAll();
+    return `${window.location.origin}/invite/${token}`;
+  }, [fetchAll]);
+
+  const acceptInvite = useCallback(
+    async (partnershipId: string) => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error("Not authenticated");
+
+      const { error: updateError } = await supabase
+        .from("partnerships")
+        .update({ partner_id: user.id, status: "active" })
+        .eq("id", partnershipId);
+
+      if (updateError) throw updateError;
+      await fetchAll();
+    },
+    [fetchAll]
+  );
+
+  const declineInvite = useCallback(
+    async (partnershipId: string) => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error("Not authenticated");
+
+      const { error: updateError } = await supabase
+        .from("partnerships")
+        .update({ status: "declined" })
+        .eq("id", partnershipId);
+
+      if (updateError) throw updateError;
+      await fetchAll();
+    },
+    [fetchAll]
+  );
+
+  const removePartner = useCallback(
+    async (partnershipId: string) => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error("Not authenticated");
+
+      const { error: deleteError } = await supabase
+        .from("partnerships")
+        .delete()
+        .eq("id", partnershipId);
+
+      if (deleteError) throw deleteError;
+      await fetchAll();
+    },
+    [fetchAll]
+  );
+
+  const sendNudge = useCallback(
+    async (
+      partnershipId: string,
+      receiverId: string,
+      message: string
+    ) => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error("Not authenticated");
+
+      const { error: insertError } = await supabase.from("nudges").insert({
+        partnership_id: partnershipId,
+        sender_id: user.id,
+        receiver_id: receiverId,
+        message,
+      });
+
+      if (insertError) throw insertError;
+      // Don't need to refresh all — nudge doesn't affect partnership state
+    },
+    []
+  );
+
+  const markNudgesRead = useCallback(async () => {
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) throw new Error("Not authenticated");
+
+    const unreadIds = nudges.filter((n) => !n.read).map((n) => n.id);
+    if (unreadIds.length === 0) return;
+
+    const { error: updateError } = await supabase
+      .from("nudges")
+      .update({ read: true })
+      .in("id", unreadIds)
+      .eq("receiver_id", user.id);
+
+    if (updateError) throw updateError;
+
+    // Optimistically update local state
+    setNudges((prev) =>
+      prev.map((n) => (unreadIds.includes(n.id) ? { ...n, read: true } : n))
+    );
+  }, [nudges]);
+
+  // ─── Snapshot ─────────────────────────────────────────
+
+  const fetchPartnerSnapshot = useCallback(
+    async (partnerUserId: string): Promise<PartnerSnapshot> => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error("Not authenticated");
+
+      // Verify active partnership exists
+      const { data: partnership, error: partnershipError } = await supabase
+        .from("partnerships")
+        .select("id")
+        .eq("status", "active")
+        .or(
+          `and(requester_id.eq.${user.id},partner_id.eq.${partnerUserId}),and(requester_id.eq.${partnerUserId},partner_id.eq.${user.id})`
+        )
+        .limit(1)
+        .single();
+
+      if (partnershipError || !partnership) {
+        throw new Error("No active partnership found");
+      }
+
+      // Fetch partner's data in parallel — RLS partner read policies allow this
+      const [profileRes, routinesRes, checkInsRes, stacksRes] =
+        await Promise.all([
+          supabase
+            .from("profiles")
+            .select("id, display_name")
+            .eq("id", partnerUserId)
+            .single(),
+          supabase
+            .from("routines")
+            .select("*")
+            .eq("user_id", partnerUserId)
+            .is("archived_at", null)
+            .order("sort_order", { ascending: true }),
+          supabase
+            .from("check_ins")
+            .select("*")
+            .eq("user_id", partnerUserId),
+          supabase
+            .from("habit_stacks")
+            .select("*")
+            .eq("user_id", partnerUserId)
+            .order("created_at", { ascending: true }),
+        ]);
+
+      if (profileRes.error) throw profileRes.error;
+      if (routinesRes.error) throw routinesRes.error;
+      if (checkInsRes.error) throw checkInsRes.error;
+      if (stacksRes.error) throw stacksRes.error;
+
+      const routines = (routinesRes.data ?? []) as Routine[];
+      const checkIns = (checkInsRes.data ?? []) as CheckIn[];
+
+      const { currentStreak, longestStreak, completionRateThisWeek } =
+        computeStreaks(checkIns, routines);
+
+      return {
+        profile: profileRes.data as Pick<Profile, "id" | "display_name">,
+        routines,
+        checkIns,
+        stacks: (stacksRes.data ?? []) as HabitStack[],
+        currentStreak,
+        longestStreak,
+        completionRateThisWeek,
+      };
+    },
+    []
+  );
+
+  // ─── Return ───────────────────────────────────────────
+
+  return {
+    partnerships,
+    pendingInvites,
+    sentInvites,
+    unreadNudgeCount,
+    nudges,
+    loading,
+    error,
+    generateInviteLink,
+    acceptInvite,
+    declineInvite,
+    removePartner,
+    sendNudge,
+    markNudgesRead,
+    fetchPartnerSnapshot,
+    refreshPartners: fetchAll,
+  };
+}

--- a/src/hooks/useStacks.ts
+++ b/src/hooks/useStacks.ts
@@ -21,7 +21,7 @@ interface UseStacksReturn {
  * Build enriched stacks by joining raw habit_stacks with routines in JS.
  * Safer than relying on Supabase PostgREST multi-FK joins.
  */
-function buildStacksWithRoutines(
+export function buildStacksWithRoutines(
   rawStacks: HabitStack[],
   routines: Routine[]
 ): StackWithRoutines[] {
@@ -51,7 +51,7 @@ function buildStacksWithRoutines(
  * Group enriched stacks into chains by anchor_routine_id.
  * Each chain has one anchor and one or more ordered steps.
  */
-function buildChains(stacks: StackWithRoutines[]): StackChain[] {
+export function buildChains(stacks: StackWithRoutines[]): StackChain[] {
   const chainMap = new Map<
     string,
     { anchor: Routine; steps: { stack: HabitStack; routine: Routine }[] }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -77,8 +77,11 @@ export async function updateSession(request: NextRequest) {
       `[Middleware Check] Path: ${url.pathname} | Onboarded: ${isOnboardingComplete}`
     );
 
+    const isInviteRoute = url.pathname.startsWith("/invite");
+
     if (!isOnboardingComplete) {
-      if (!isOnboardingRoute) {
+      // Allow invite routes even if onboarding isn't complete
+      if (!isOnboardingRoute && !isInviteRoute) {
         url.pathname = "/onboarding";
         return redirectWithCookies(url);
       }

--- a/src/lib/validators/__tests__/validators.test.ts
+++ b/src/lib/validators/__tests__/validators.test.ts
@@ -323,8 +323,8 @@ describe("signupSchema", () => {
     });
     expect(result.success).toBe(false);
     if (!result.success) {
-      const mismatchError = result.error.issues.find(
-        (i) => i.path.includes("confirmPassword")
+      const mismatchError = result.error.issues.find((i) =>
+        i.path.includes("confirmPassword")
       );
       expect(mismatchError).toBeDefined();
     }

--- a/src/lib/validators/__tests__/validators.test.ts
+++ b/src/lib/validators/__tests__/validators.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect } from "vitest";
+import { routineSchema, tagEnum, timeOfDayEnum } from "../routine";
+import { identitySchema } from "../identity";
+import { stackSchema } from "../stack";
+import { loginSchema, signupSchema } from "../auth";
+import { inviteByEmailSchema, nudgeSchema } from "../partner";
+
+// ─── routineSchema ───────────────────────────────────────
+
+describe("routineSchema", () => {
+  it("accepts valid routine data", () => {
+    const result = routineSchema.safeParse({
+      name: "Morning coffee",
+      tag: "neutral",
+      time_of_day: "morning",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace from name", () => {
+    const result = routineSchema.parse({
+      name: "  Journaling  ",
+      tag: "positive",
+    });
+    expect(result.name).toBe("Journaling");
+  });
+
+  it("rejects empty name", () => {
+    const result = routineSchema.safeParse({
+      name: "",
+      tag: "positive",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only name", () => {
+    const result = routineSchema.safeParse({
+      name: "   ",
+      tag: "positive",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects name over 100 characters", () => {
+    const result = routineSchema.safeParse({
+      name: "a".repeat(101),
+      tag: "positive",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts name at exactly 100 characters", () => {
+    const result = routineSchema.safeParse({
+      name: "a".repeat(100),
+      tag: "positive",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid tag", () => {
+    const result = routineSchema.safeParse({
+      name: "Test",
+      tag: "invalid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid tags", () => {
+    for (const tag of ["positive", "negative", "neutral"]) {
+      const result = routineSchema.safeParse({ name: "Test", tag });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("accepts null time_of_day", () => {
+    const result = routineSchema.safeParse({
+      name: "Test",
+      tag: "positive",
+      time_of_day: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts undefined time_of_day", () => {
+    const result = routineSchema.safeParse({
+      name: "Test",
+      tag: "positive",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts all valid time_of_day values", () => {
+    for (const tod of ["morning", "afternoon", "evening", "night"]) {
+      const result = routineSchema.safeParse({
+        name: "Test",
+        tag: "neutral",
+        time_of_day: tod,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid time_of_day", () => {
+    const result = routineSchema.safeParse({
+      name: "Test",
+      tag: "neutral",
+      time_of_day: "midnight",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("tagEnum", () => {
+  it("accepts valid tags", () => {
+    expect(tagEnum.safeParse("positive").success).toBe(true);
+    expect(tagEnum.safeParse("negative").success).toBe(true);
+    expect(tagEnum.safeParse("neutral").success).toBe(true);
+  });
+
+  it("rejects invalid value", () => {
+    expect(tagEnum.safeParse("bad").success).toBe(false);
+  });
+});
+
+describe("timeOfDayEnum", () => {
+  it("accepts valid values", () => {
+    for (const v of ["morning", "afternoon", "evening", "night"]) {
+      expect(timeOfDayEnum.safeParse(v).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid value", () => {
+    expect(timeOfDayEnum.safeParse("dawn").success).toBe(false);
+  });
+});
+
+// ─── identitySchema ──────────────────────────────────────
+
+describe("identitySchema", () => {
+  it("accepts valid statement", () => {
+    const result = identitySchema.safeParse({
+      statement: "I am someone who reads daily",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace", () => {
+    const result = identitySchema.parse({
+      statement: "  I am healthy  ",
+    });
+    expect(result.statement).toBe("I am healthy");
+  });
+
+  it("rejects empty statement", () => {
+    const result = identitySchema.safeParse({ statement: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only statement", () => {
+    const result = identitySchema.safeParse({ statement: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects statement over 500 characters", () => {
+    const result = identitySchema.safeParse({
+      statement: "a".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts statement at exactly 500 characters", () => {
+    const result = identitySchema.safeParse({
+      statement: "a".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── stackSchema ─────────────────────────────────────────
+
+describe("stackSchema", () => {
+  const validAnchor = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+  const validStacked = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22";
+
+  it("accepts valid stack data", () => {
+    const result = stackSchema.safeParse({
+      anchor_routine_id: validAnchor,
+      stacked_routine_id: validStacked,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional position", () => {
+    const result = stackSchema.safeParse({
+      anchor_routine_id: validAnchor,
+      stacked_routine_id: validStacked,
+      position: 2,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-UUID anchor_routine_id", () => {
+    const result = stackSchema.safeParse({
+      anchor_routine_id: "not-a-uuid",
+      stacked_routine_id: validStacked,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-UUID stacked_routine_id", () => {
+    const result = stackSchema.safeParse({
+      anchor_routine_id: validAnchor,
+      stacked_routine_id: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects self-stacking (same anchor and stacked)", () => {
+    const sameId = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    const result = stackSchema.safeParse({
+      anchor_routine_id: sameId,
+      stacked_routine_id: sameId,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const selfStackError = result.error.issues.find(
+        (i) => i.message === "A routine cannot be stacked on itself"
+      );
+      expect(selfStackError).toBeDefined();
+    }
+  });
+
+  it("rejects negative position", () => {
+    const result = stackSchema.safeParse({
+      anchor_routine_id: validAnchor,
+      stacked_routine_id: validStacked,
+      position: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── loginSchema ─────────────────────────────────────────
+
+describe("loginSchema", () => {
+  it("accepts valid login data", () => {
+    const result = loginSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims email whitespace", () => {
+    const result = loginSchema.parse({
+      email: "  test@example.com  ",
+      password: "password123",
+    });
+    expect(result.email).toBe("test@example.com");
+  });
+
+  it("rejects empty email", () => {
+    const result = loginSchema.safeParse({
+      email: "",
+      password: "password123",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid email format", () => {
+    const result = loginSchema.safeParse({
+      email: "not-an-email",
+      password: "password123",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty password", () => {
+    const result = loginSchema.safeParse({
+      email: "test@example.com",
+      password: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── signupSchema ────────────────────────────────────────
+
+describe("signupSchema", () => {
+  it("accepts valid signup data", () => {
+    const result = signupSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+      confirmPassword: "password123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects password under 6 characters", () => {
+    const result = signupSchema.safeParse({
+      email: "test@example.com",
+      password: "12345",
+      confirmPassword: "12345",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects password over 72 characters", () => {
+    const long = "a".repeat(73);
+    const result = signupSchema.safeParse({
+      email: "test@example.com",
+      password: long,
+      confirmPassword: long,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects mismatched passwords", () => {
+    const result = signupSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+      confirmPassword: "password456",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const mismatchError = result.error.issues.find(
+        (i) => i.path.includes("confirmPassword")
+      );
+      expect(mismatchError).toBeDefined();
+    }
+  });
+
+  it("accepts password at exactly 6 characters", () => {
+    const result = signupSchema.safeParse({
+      email: "test@example.com",
+      password: "123456",
+      confirmPassword: "123456",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── inviteByEmailSchema ─────────────────────────────────
+
+describe("inviteByEmailSchema", () => {
+  it("accepts valid email", () => {
+    const result = inviteByEmailSchema.safeParse({
+      email: "friend@example.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("lowercases email", () => {
+    const result = inviteByEmailSchema.parse({
+      email: "FRIEND@Example.COM",
+    });
+    expect(result.email).toBe("friend@example.com");
+  });
+
+  it("rejects invalid email", () => {
+    const result = inviteByEmailSchema.safeParse({
+      email: "not-valid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty email", () => {
+    const result = inviteByEmailSchema.safeParse({ email: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── nudgeSchema ─────────────────────────────────────────
+
+describe("nudgeSchema", () => {
+  it("accepts valid message", () => {
+    const result = nudgeSchema.safeParse({
+      message: "Keep going! 💪",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace", () => {
+    const result = nudgeSchema.parse({
+      message: "  Stay strong  ",
+    });
+    expect(result.message).toBe("Stay strong");
+  });
+
+  it("rejects empty message", () => {
+    const result = nudgeSchema.safeParse({ message: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects message over 200 characters", () => {
+    const result = nudgeSchema.safeParse({
+      message: "a".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts message at exactly 200 characters", () => {
+    const result = nudgeSchema.safeParse({
+      message: "a".repeat(200),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/validators/partner.ts
+++ b/src/lib/validators/partner.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+/** Validate invite-by-email input */
+export const inviteByEmailSchema = z.object({
+  email: z
+    .string()
+    .email("Please enter a valid email address")
+    .trim()
+    .toLowerCase(),
+});
+
+/** Validate nudge message */
+export const nudgeSchema = z.object({
+  message: z.string().min(1, "Message is required").max(200).trim(),
+});
+
+export type InviteByEmailData = z.infer<typeof inviteByEmailSchema>;
+export type NudgeData = z.infer<typeof nudgeSchema>;

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -52,10 +52,7 @@ export function createMockSupabase() {
   }
 
   /** Override the next mutation (insert/update/delete) result */
-  function setNextMutationResult(result: {
-    data?: unknown;
-    error?: unknown;
-  }) {
+  function setNextMutationResult(result: { data?: unknown; error?: unknown }) {
     nextMutationResult = {
       data: result.data ?? null,
       error: result.error ?? null,
@@ -128,30 +125,34 @@ export function createMockSupabase() {
     });
 
     // Make the builder itself thenable so `await supabase.from(...).select(...)` works
-    builder.then = vi.fn().mockImplementation(
-      (
-        resolve: (value: unknown) => void,
-        reject?: (reason: unknown) => void
-      ) => {
-        if (mutationType !== "select" && nextMutationResult) {
-          const result = nextMutationResult;
-          nextMutationResult = null;
-          return Promise.resolve(result).then(resolve, reject);
+    builder.then = vi
+      .fn()
+      .mockImplementation(
+        (
+          resolve: (value: unknown) => void,
+          reject?: (reason: unknown) => void
+        ) => {
+          if (mutationType !== "select" && nextMutationResult) {
+            const result = nextMutationResult;
+            nextMutationResult = null;
+            return Promise.resolve(result).then(resolve, reject);
+          }
+          const data = tableData.get(table) ?? [];
+          return Promise.resolve({
+            data: isSingle ? (data[0] ?? null) : data,
+            error: null,
+          }).then(resolve, reject);
         }
-        const data = tableData.get(table) ?? [];
-        return Promise.resolve({
-          data: isSingle ? (data[0] ?? null) : data,
-          error: null,
-        }).then(resolve, reject);
-      }
-    );
+      );
 
     return builder;
   }
 
   // The mock supabase client
   const mockSupabase = {
-    from: vi.fn().mockImplementation((table: string) => createQueryBuilder(table)),
+    from: vi
+      .fn()
+      .mockImplementation((table: string) => createQueryBuilder(table)),
     auth: {
       getUser: vi.fn().mockResolvedValue({
         data: { user: mockUser() },

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -1,0 +1,181 @@
+import { vi } from "vitest";
+
+/**
+ * Mock Supabase client for testing hooks and components.
+ *
+ * Usage in a test file:
+ * ```ts
+ * import { createMockSupabase, mockUser } from "@/test/mocks/supabase";
+ *
+ * vi.mock("@/lib/supabase/client", () => ({
+ *   createClient: () => mockSupabase,
+ * }));
+ *
+ * const { mockSupabase, setMockData } = createMockSupabase();
+ *
+ * // Configure mock data for a table
+ * setMockData("routines", [
+ *   { id: "1", name: "Morning coffee", tag: "neutral", ... },
+ * ]);
+ *
+ * // Configure auth user
+ * mockSupabase.auth.getUser.mockResolvedValue({
+ *   data: { user: mockUser() },
+ *   error: null,
+ * });
+ * ```
+ */
+
+/** Create a test user with sensible defaults */
+export function mockUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "user-1",
+    email: "test@example.com",
+    app_metadata: {},
+    user_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+/** Create a fully mocked Supabase client */
+export function createMockSupabase() {
+  // Store mock data per table
+  const tableData = new Map<string, unknown[]>();
+  // Store per-call overrides: { data, error } for insert/update/delete
+  let nextMutationResult: { data: unknown; error: unknown } | null = null;
+
+  /** Set mock data that SELECT queries will return for a given table */
+  function setMockData(table: string, data: unknown[]) {
+    tableData.set(table, data);
+  }
+
+  /** Override the next mutation (insert/update/delete) result */
+  function setNextMutationResult(result: {
+    data?: unknown;
+    error?: unknown;
+  }) {
+    nextMutationResult = {
+      data: result.data ?? null,
+      error: result.error ?? null,
+    };
+  }
+
+  /**
+   * Build a chainable query builder mock.
+   * Every chaining method returns `this` so calls like
+   * `.from("x").select("*").eq("a", "b").order("c")` all work.
+   * The resolved value comes from tableData or nextMutationResult.
+   */
+  function createQueryBuilder(table: string) {
+    let isSingle = false;
+    let mutationType: "select" | "insert" | "update" | "delete" = "select";
+
+    const builder: Record<string, unknown> = {};
+
+    // Chaining methods — all return the builder
+    const chainMethods = [
+      "select",
+      "eq",
+      "neq",
+      "in",
+      "is",
+      "or",
+      "order",
+      "limit",
+      "match",
+      "filter",
+      "not",
+      "gt",
+      "gte",
+      "lt",
+      "lte",
+    ];
+
+    chainMethods.forEach((method) => {
+      builder[method] = vi.fn().mockImplementation(() => builder);
+    });
+
+    // Mutation starters — also chainable
+    builder.insert = vi.fn().mockImplementation(() => {
+      mutationType = "insert";
+      return builder;
+    });
+    builder.update = vi.fn().mockImplementation(() => {
+      mutationType = "update";
+      return builder;
+    });
+    builder.delete = vi.fn().mockImplementation(() => {
+      mutationType = "delete";
+      return builder;
+    });
+
+    // single() modifier
+    builder.single = vi.fn().mockImplementation(() => {
+      isSingle = true;
+      // Resolve immediately with data
+      const data = tableData.get(table) ?? [];
+      if (mutationType !== "select" && nextMutationResult) {
+        const result = nextMutationResult;
+        nextMutationResult = null;
+        return Promise.resolve(result);
+      }
+      return Promise.resolve({
+        data: isSingle ? (data[0] ?? null) : data,
+        error: null,
+      });
+    });
+
+    // Make the builder itself thenable so `await supabase.from(...).select(...)` works
+    builder.then = vi.fn().mockImplementation(
+      (
+        resolve: (value: unknown) => void,
+        reject?: (reason: unknown) => void
+      ) => {
+        if (mutationType !== "select" && nextMutationResult) {
+          const result = nextMutationResult;
+          nextMutationResult = null;
+          return Promise.resolve(result).then(resolve, reject);
+        }
+        const data = tableData.get(table) ?? [];
+        return Promise.resolve({
+          data: isSingle ? (data[0] ?? null) : data,
+          error: null,
+        }).then(resolve, reject);
+      }
+    );
+
+    return builder;
+  }
+
+  // The mock supabase client
+  const mockSupabase = {
+    from: vi.fn().mockImplementation((table: string) => createQueryBuilder(table)),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: mockUser() },
+        error: null,
+      }),
+      signInWithPassword: vi.fn().mockResolvedValue({
+        data: { user: mockUser(), session: {} },
+        error: null,
+      }),
+      signInWithOAuth: vi.fn().mockResolvedValue({
+        data: { url: "https://oauth.test" },
+        error: null,
+      }),
+      signUp: vi.fn().mockResolvedValue({
+        data: { user: mockUser(), session: {} },
+        error: null,
+      }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+    },
+  };
+
+  return {
+    mockSupabase,
+    setMockData,
+    setNextMutationResult,
+  };
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,4 +1,5 @@
 import { Tag, TimeOfDay } from "./common";
+import type { PartnershipStatus } from "./partners";
 
 export interface Database {
   public: {
@@ -162,6 +163,67 @@ export interface Database {
           user_id?: string;
         };
       };
+      partnerships: {
+        Row: {
+          id: string; // uuid
+          requester_id: string; // uuid
+          partner_id: string | null; // uuid, null while pending
+          invite_token: string;
+          invite_email: string | null;
+          status: PartnershipStatus;
+          created_at: string; // timestamptz
+          updated_at: string; // timestamptz
+        };
+        Insert: {
+          id?: string;
+          requester_id: string;
+          partner_id?: string | null;
+          invite_token: string;
+          invite_email?: string | null;
+          status?: PartnershipStatus;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          requester_id?: string;
+          partner_id?: string | null;
+          invite_token?: string;
+          invite_email?: string | null;
+          status?: PartnershipStatus;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
+      nudges: {
+        Row: {
+          id: string; // uuid
+          partnership_id: string; // uuid
+          sender_id: string; // uuid
+          receiver_id: string; // uuid
+          message: string;
+          read: boolean;
+          created_at: string; // timestamptz
+        };
+        Insert: {
+          id?: string;
+          partnership_id: string;
+          sender_id: string;
+          receiver_id: string;
+          message?: string;
+          read?: boolean;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          partnership_id?: string;
+          sender_id?: string;
+          receiver_id?: string;
+          message?: string;
+          read?: boolean;
+          created_at?: string;
+        };
+      };
     };
   };
 }
@@ -174,3 +236,6 @@ export type HabitStack = Database["public"]["Tables"]["habit_stacks"]["Row"];
 export type Identity = Database["public"]["Tables"]["identities"]["Row"];
 export type IdentityHabit =
   Database["public"]["Tables"]["identity_habits"]["Row"];
+export type PartnershipRow =
+  Database["public"]["Tables"]["partnerships"]["Row"];
+export type NudgeRow = Database["public"]["Tables"]["nudges"]["Row"];

--- a/src/types/partners.ts
+++ b/src/types/partners.ts
@@ -1,0 +1,54 @@
+import type { Profile, Routine, CheckIn, HabitStack } from "./database";
+
+/** Partnership status progression: pending → active or declined */
+export type PartnershipStatus = "pending" | "active" | "declined";
+
+/** Raw partnership row from the database */
+export interface Partnership {
+  id: string;
+  requester_id: string;
+  partner_id: string | null;
+  invite_token: string;
+  invite_email: string | null;
+  status: PartnershipStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Partnership enriched with the partner's profile info */
+export interface PartnershipWithProfile extends Partnership {
+  partner_profile: Pick<Profile, "id" | "display_name">;
+}
+
+/** Nudge row from the database */
+export interface Nudge {
+  id: string;
+  partnership_id: string;
+  sender_id: string;
+  receiver_id: string;
+  message: string;
+  read: boolean;
+  created_at: string;
+}
+
+/** Predefined nudge messages — no free-text to keep it simple */
+export const NUDGE_MESSAGES = [
+  "Keep going! 💪",
+  "Don't break the chain! 🔥",
+  "Your future self will thank you 🙌",
+  "Just one small step today ✨",
+  "I believe in you! 🌟",
+] as const;
+
+export type NudgeMessage = (typeof NUDGE_MESSAGES)[number];
+
+/** What the partner sees — read-only snapshot of another user's data */
+export interface PartnerSnapshot {
+  profile: Pick<Profile, "id" | "display_name">;
+  routines: Routine[];
+  checkIns: CheckIn[];
+  stacks: HabitStack[];
+  currentStreak: number;
+  longestStreak: number;
+  completionRateThisWeek: number;
+}

--- a/supabase/migrations/20260311000000_accountability_partners.sql
+++ b/supabase/migrations/20260311000000_accountability_partners.sql
@@ -1,0 +1,171 @@
+-- ============================================================
+-- Accountability Partners (US-11)
+-- Two new tables: partnerships + nudges
+-- Partner read policies on existing tables
+-- ============================================================
+
+-- =========================
+-- Table: partnerships
+-- =========================
+
+CREATE TABLE public.partnerships (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  requester_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  partner_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE,
+  invite_token TEXT NOT NULL UNIQUE,
+  invite_email TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'declined')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =========================
+-- Table: nudges
+-- =========================
+
+CREATE TABLE public.nudges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  partnership_id UUID NOT NULL REFERENCES public.partnerships(id) ON DELETE CASCADE,
+  sender_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  receiver_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  message TEXT NOT NULL DEFAULT 'Keep going! 💪',
+  read BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- =========================
+-- Enable RLS
+-- =========================
+
+ALTER TABLE public.partnerships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.nudges ENABLE ROW LEVEL SECURITY;
+
+-- =========================
+-- RLS: partnerships
+-- =========================
+
+CREATE POLICY "Users see own partnerships" ON public.partnerships FOR SELECT
+  USING (auth.uid() = requester_id OR auth.uid() = partner_id);
+
+CREATE POLICY "Users create partnerships" ON public.partnerships FOR INSERT
+  WITH CHECK (auth.uid() = requester_id);
+
+CREATE POLICY "Users update own partnerships" ON public.partnerships FOR UPDATE
+  USING (auth.uid() = requester_id OR auth.uid() = partner_id);
+
+CREATE POLICY "Users delete own partnerships" ON public.partnerships FOR DELETE
+  USING (auth.uid() = requester_id OR auth.uid() = partner_id);
+
+-- =========================
+-- RLS: nudges
+-- =========================
+
+CREATE POLICY "Users see own nudges" ON public.nudges FOR SELECT
+  USING (auth.uid() = sender_id OR auth.uid() = receiver_id);
+
+CREATE POLICY "Users send nudges" ON public.nudges FOR INSERT
+  WITH CHECK (auth.uid() = sender_id);
+
+CREATE POLICY "Receivers update nudges" ON public.nudges FOR UPDATE
+  USING (auth.uid() = receiver_id);
+
+-- =========================
+-- Partner read policies on existing tables
+-- These are SELECT-only and additive (Postgres OR's permissive policies).
+-- Existing "Users access own data" FOR ALL policies remain untouched.
+-- =========================
+
+-- Helper: checks if auth.uid() has an active partnership with the row's user_id
+-- Used in every policy below. Written inline since Supabase doesn't support
+-- reusable RLS functions cleanly.
+
+-- profiles: partners can read each other's profile
+CREATE POLICY "Partners can view profiles" ON public.profiles FOR SELECT
+  USING (
+    auth.uid() = id
+    OR EXISTS (
+      SELECT 1 FROM public.partnerships
+      WHERE status = 'active'
+      AND (
+        (requester_id = auth.uid() AND partner_id = profiles.id)
+        OR (partner_id = auth.uid() AND requester_id = profiles.id)
+      )
+    )
+  );
+
+-- routines: partners can read each other's routines
+CREATE POLICY "Partners can view routines" ON public.routines FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.partnerships
+      WHERE status = 'active'
+      AND (
+        (requester_id = auth.uid() AND partner_id = routines.user_id)
+        OR (partner_id = auth.uid() AND requester_id = routines.user_id)
+      )
+    )
+  );
+
+-- check_ins: partners can read each other's check-ins
+CREATE POLICY "Partners can view check_ins" ON public.check_ins FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.partnerships
+      WHERE status = 'active'
+      AND (
+        (requester_id = auth.uid() AND partner_id = check_ins.user_id)
+        OR (partner_id = auth.uid() AND requester_id = check_ins.user_id)
+      )
+    )
+  );
+
+-- habit_stacks: partners can read each other's stacks
+CREATE POLICY "Partners can view habit_stacks" ON public.habit_stacks FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.partnerships
+      WHERE status = 'active'
+      AND (
+        (requester_id = auth.uid() AND partner_id = habit_stacks.user_id)
+        OR (partner_id = auth.uid() AND requester_id = habit_stacks.user_id)
+      )
+    )
+  );
+
+-- identities: partners can read each other's identities
+CREATE POLICY "Partners can view identities" ON public.identities FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.partnerships
+      WHERE status = 'active'
+      AND (
+        (requester_id = auth.uid() AND partner_id = identities.user_id)
+        OR (partner_id = auth.uid() AND requester_id = identities.user_id)
+      )
+    )
+  );
+
+-- identity_habits: partners can read each other's identity-habit links
+CREATE POLICY "Partners can view identity_habits" ON public.identity_habits FOR SELECT
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.partnerships
+      WHERE status = 'active'
+      AND (
+        (requester_id = auth.uid() AND partner_id = identity_habits.user_id)
+        OR (partner_id = auth.uid() AND requester_id = identity_habits.user_id)
+      )
+    )
+  );
+
+-- =========================
+-- Triggers
+-- =========================
+
+CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.partnerships
+  FOR EACH ROW EXECUTE PROCEDURE moddatetime(updated_at);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary", "lcov", "html"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/test/**",
+        "src/types/**",
+        "src/app/**/layout.tsx",
+        "src/app/**/page.tsx",
+        "src/app/**/route.ts",
+        "src/styles/**",
+        "src/lib/supabase/**",
+        "src/hooks/useAuth.ts",
+      ],
+      thresholds: {
+        statements: 80,
+        branches: 70,
+        functions: 80,
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
**Accountability Partners (US-11)**
- Database migration: partnerships + nudges tables with RLS
- Partner read policies on all existing tables
- Invite link generation + acceptance flow
- Partner progress shared view (read-only scorecard, stacks, streaks)
- Nudge system with predefined messages + unread badge
- Partners page + nav update

**Test Suite (80%+ coverage)**
- 255 tests across 11 test files
- Vitest + React Testing Library
- Validators, hook helpers, hook integration, component tests
- 84.6% statements, 89.4% lines, 92.7% functions